### PR TITLE
refactor: decompose MessageList lifecycle and rendering

### DIFF
--- a/frontend/src/components/MessageList.tsx
+++ b/frontend/src/components/MessageList.tsx
@@ -1,58 +1,8 @@
-import { useState, useEffect, useRef, useCallback, useLayoutEffect } from "react";
 import { useAuth } from "../context/AuthContext";
 import { useTheme } from "../context/ThemeContext";
-import { getRoomMessages, getRoomMessagesNewer } from "../services/api";
-import { logError } from "../utils/logger";
-import { getUserColorPalette } from "../utils/userColors";
 import type { Message, MessageContextResponse } from "../types";
-
-// Local types
-interface SystemMessage {
-  id: string;
-  type: "system";
-  content: string;
-  timestamp: number;
-}
-
-type ChatItem = Message | SystemMessage;
-
-type PendingScrollAdjustment =
-  | { type: "initial" }
-  | { type: "context-target"; targetMessageId: number }
-  | {
-      type: "prepend";
-      previousScrollTop: number;
-      previousScrollHeight: number;
-      anchorMessageId: number | null;
-      anchorTop: number | null;
-    }
-  | { type: "append"; behavior: ScrollBehavior };
-
-const JUMP_TO_LATEST_MIN_HIDDEN_MESSAGES = 50;
-const INITIAL_HISTORY_PAGE_SIZE = 75;
-const OLDER_HISTORY_PAGE_SIZE = 100;
-const TOP_PREFETCH_ROOT_MARGIN = "900px";
-
-function isStrictlyNewerThan(
-  candidate: Message,
-  reference: Message,
-): boolean {
-  const candidateTime = parseTimestamp(candidate.created_at);
-  const referenceTime = parseTimestamp(reference.created_at);
-
-  if (
-    candidateTime != null &&
-    referenceTime != null &&
-    candidateTime !== referenceTime
-  ) {
-    return candidateTime > referenceTime;
-  }
-
-  if (candidateTime != null && referenceTime == null) return true;
-  if (candidateTime == null && referenceTime != null) return false;
-
-  return candidate.id > reference.id;
-}
+import { MessageFeedContent } from "./message-list/MessageFeedContent";
+import { useMessageFeedLifecycle } from "../hooks/useMessageFeedLifecycle";
 
 interface MessageListProps {
   roomId: number;
@@ -64,41 +14,6 @@ interface MessageListProps {
   onIncomingMessagesProcessed?: () => void;
   scrollToLatestSignal?: number;
   onExitContextMode?: () => void;
-}
-
-function normalizeToUtcIso(isoString: string): string {
-  const hasTimezoneSuffix = /(?:Z|[+-]\d{2}:\d{2})$/i.test(isoString);
-  return hasTimezoneSuffix ? isoString : `${isoString}Z`;
-}
-
-function parseTimestamp(isoString: string | null | undefined): number | null {
-  if (!isoString) return null;
-  const timestamp = Date.parse(normalizeToUtcIso(isoString));
-  return Number.isNaN(timestamp) ? null : timestamp;
-}
-
-function findFirstUnreadMessageId(
-  items: ChatItem[],
-  snapshot: string | null | undefined,
-  currentUserId: number | null | undefined,
-): number | null {
-  const snapshotTimestamp = parseTimestamp(snapshot);
-  if (snapshotTimestamp == null) return null;
-
-  const unreadMessage = items.find((item) => {
-    if ("type" in item && item.type === "system") return false;
-    if (currentUserId != null && (item as Message).user_id === currentUserId) {
-      return false;
-    }
-    const messageTimestamp = parseTimestamp((item as Message).created_at);
-    return messageTimestamp != null && messageTimestamp > snapshotTimestamp;
-  });
-
-  if (!unreadMessage || ("type" in unreadMessage && unreadMessage.type === "system")) {
-    return null;
-  }
-
-  return (unreadMessage as Message).id;
 }
 
 export default function MessageList({
@@ -114,706 +29,36 @@ export default function MessageList({
 }: MessageListProps) {
   const { token, user } = useAuth();
   const { theme } = useTheme();
-  const [messages, setMessages] = useState<ChatItem[]>([]);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState("");
-  // Local retry counter so the effect can refetch when user clicks "Retry"
-  const [retryCount, setRetryCount] = useState(0);
-
-  // Pagination state
-  const [nextCursor, setNextCursor] = useState<string | null>(null);
-  const [newerCursor, setNewerCursor] = useState<string | null>(null);
-  const [isLoadingMore, setIsLoadingMore] = useState(false);
-  const [isLoadingNewer, setIsLoadingNewer] = useState(false);
-  const [isInitialPositioned, setIsInitialPositioned] = useState(false);
-  const [showJumpToLatest, setShowJumpToLatest] = useState(false);
-  const [highlightedMessageId, setHighlightedMessageId] = useState<number | null>(null);
-  const [contextLiveMessages, setContextLiveMessages] = useState<Message[]>([]);
-  /**
-   * Divider anchor is resolved once per room-entry so the "NEW MESSAGES"
-   * marker does not reposition while the user keeps viewing this room.
-   */
-  const [newMessagesAnchorId, setNewMessagesAnchorId] = useState<number | null>(null);
-
-  // Refs
-  const messagesEndRef = useRef<HTMLDivElement>(null);
-  const scrollContainerRef = useRef<HTMLDivElement>(null);
-  const sentinelRef = useRef<HTMLDivElement>(null);
-  const bottomSentinelRef = useRef<HTMLDivElement>(null);
-  const pendingScrollAdjustmentRef = useRef<PendingScrollAdjustment | null>(null);
-  /** Ref avoids stale state reads in async finally blocks. */
-  const timeoutFiredRef = useRef(false);
-  const previousScrollToLatestSignalRef = useRef(scrollToLatestSignal);
-  const contextLiveMessagesRef = useRef<Message[]>([]);
-  const jumpVisibilitySuppressedRef = useRef(false);
-  const paginationEpochRef = useRef(0);
-
-  useEffect(() => {
-    contextLiveMessagesRef.current = contextLiveMessages;
-  }, [contextLiveMessages]);
-
-  const isNearBottom = useCallback((container: HTMLDivElement): boolean => {
-    const distanceFromBottom =
-      container.scrollHeight - container.scrollTop - container.clientHeight;
-    return distanceFromBottom < 100;
-  }, []);
-
-  const capturePrependAnchor = useCallback(
-    (container: HTMLDivElement): { anchorMessageId: number | null; anchorTop: number | null } => {
-      const containerTop = container.getBoundingClientRect().top;
-      const messageElements = Array.from(
-        container.querySelectorAll<HTMLElement>("[data-chat-message='true'][data-message-id]"),
-      );
-
-      const anchorElement =
-        messageElements.find(
-          (el) => el.getBoundingClientRect().bottom >= containerTop,
-        ) ?? messageElements[0];
-
-      if (!anchorElement) {
-        return { anchorMessageId: null, anchorTop: null };
-      }
-
-      const rawId = anchorElement.dataset.messageId;
-      const parsedId = rawId ? Number(rawId) : Number.NaN;
-      if (!Number.isFinite(parsedId)) {
-        return { anchorMessageId: null, anchorTop: null };
-      }
-
-      return {
-        anchorMessageId: parsedId,
-        anchorTop: anchorElement.getBoundingClientRect().top,
-      };
-    },
-    [],
-  );
-
-  const updateJumpToLatestVisibility = useCallback(() => {
-    const container = scrollContainerRef.current;
-    const shouldShowJumpActionForMode =
-      messageViewMode === "normal" || messageViewMode === "context";
-
-    if (
-      !shouldShowJumpActionForMode ||
-      !container ||
-      jumpVisibilitySuppressedRef.current ||
-      !isInitialPositioned
-    ) {
-      setShowJumpToLatest(false);
-      return;
-    }
-
-    if (messageViewMode === "context") {
-      // Context mode should offer a direct exit path to latest chat as soon as
-      // we know there are newer pages outside the loaded context slice.
-      if (newerCursor !== null) {
-        setShowJumpToLatest(true);
-        return;
-      }
-      if (isNearBottom(container)) {
-        setShowJumpToLatest(false);
-        return;
-      }
-      setShowJumpToLatest(true);
-      return;
-    }
-
-    if (isNearBottom(container)) {
-      setShowJumpToLatest(false);
-      return;
-    }
-
-    const viewportBottom = container.scrollTop + container.clientHeight;
-    const messageElements = container.querySelectorAll<HTMLElement>(
-      "[data-chat-message='true']",
-    );
-
-    let hiddenMessageCount = 0;
-    for (let i = messageElements.length - 1; i >= 0; i -= 1) {
-      const element = messageElements[i];
-      if (element.offsetTop < viewportBottom) {
-        break;
-      }
-      hiddenMessageCount += 1;
-    }
-
-    setShowJumpToLatest(
-      hiddenMessageCount >= JUMP_TO_LATEST_MIN_HIDDEN_MESSAGES,
-    );
-  }, [isInitialPositioned, isNearBottom, messageViewMode, newerCursor]);
-
-  // Apply scroll corrections after each message mutation so initial load, prepends,
-  // and real-time appends do not fight each other.
-  useLayoutEffect(() => {
-    const container = scrollContainerRef.current;
-    const adjustment = pendingScrollAdjustmentRef.current;
-    if (!container || !adjustment) return;
-
-    if (adjustment.type === "initial") {
-      container.scrollTop = container.scrollHeight;
-      setIsInitialPositioned(true);
-    } else if (adjustment.type === "context-target") {
-      const targetElement = container.querySelector<HTMLElement>(
-        `[data-message-id='${adjustment.targetMessageId}']`,
-      );
-      if (targetElement) {
-        targetElement.scrollIntoView({ block: "center", behavior: "auto" });
-      } else {
-        container.scrollTop = container.scrollHeight;
-      }
-      setIsInitialPositioned(true);
-    } else if (adjustment.type === "prepend") {
-      if (
-        adjustment.anchorMessageId !== null &&
-        adjustment.anchorTop !== null
-      ) {
-        const anchorElement = container.querySelector<HTMLElement>(
-          `[data-message-id='${adjustment.anchorMessageId}']`,
-        );
-        if (anchorElement) {
-          const newAnchorTop = anchorElement.getBoundingClientRect().top;
-          // Keep the same message "pinned" in viewport after prepending variable-height rows.
-          container.scrollTop += newAnchorTop - adjustment.anchorTop;
-        } else {
-          const newScrollHeight = container.scrollHeight;
-          const heightDelta = newScrollHeight - adjustment.previousScrollHeight;
-          container.scrollTop = adjustment.previousScrollTop + heightDelta;
-        }
-      } else {
-        const newScrollHeight = container.scrollHeight;
-        const heightDelta = newScrollHeight - adjustment.previousScrollHeight;
-        container.scrollTop = adjustment.previousScrollTop + heightDelta;
-      }
-    } else {
-      messagesEndRef.current?.scrollIntoView({ behavior: adjustment.behavior });
-    }
-
-    pendingScrollAdjustmentRef.current = null;
-  }, [messages]);
-
-  // Density changes alter message heights; pin to latest so on-screen context
-  // does not drift upward when switching between tight and comfy modes.
-  useLayoutEffect(() => {
-    if (!isInitialPositioned) return;
-    const container = scrollContainerRef.current;
-    if (!container) return;
-    container.scrollTop = container.scrollHeight;
-    setShowJumpToLatest(false);
-  }, [density, isInitialPositioned]);
-
-  useEffect(() => {
-    if (messageViewMode !== "context" || !messageContext) return;
-
-    paginationEpochRef.current += 1;
-    setError("");
-    setLoading(false);
-    setIsInitialPositioned(false);
-    setShowJumpToLatest(false);
-    setContextLiveMessages([]);
-    setNextCursor(messageContext.older_cursor);
-    setNewerCursor(messageContext.newer_cursor);
-    setHighlightedMessageId(messageContext.target_message_id);
-    pendingScrollAdjustmentRef.current = {
-      type: "context-target",
-      targetMessageId: messageContext.target_message_id,
-    };
-    setMessages(messageContext.messages);
-  }, [messageContext, messageViewMode]);
-
-  // Fetch history when room changes in normal mode. Defer fetch to next tick so
-  // React Strict Mode cleanup runs before the first fetch starts.
-  useEffect(() => {
-    if (messageViewMode !== "normal") return;
-
-    const abortController = new AbortController();
-    let timeoutId: number | undefined;
-    const bufferedContextTail = contextLiveMessagesRef.current;
-
-    if (token) {
-      paginationEpochRef.current += 1;
-      setError("");
-      setLoading(true);
-      setNextCursor(null);
-      setNewerCursor(null);
-      setContextLiveMessages([]);
-      setHighlightedMessageId(null);
-      setIsInitialPositioned(false);
-      setShowJumpToLatest(false);
-      setNewMessagesAnchorId(null);
-      pendingScrollAdjustmentRef.current = null;
-    }
-    const activeEpoch = paginationEpochRef.current;
-
-    async function fetchMessages() {
-      if (!token) return;
-
-      timeoutFiredRef.current = false;
-
-      timeoutId = window.setTimeout(() => {
-        timeoutFiredRef.current = true;
-        setError("Loading messages is taking longer than expected. The server may be waking up.");
-        setLoading(false);
-      }, 5000);
-
-      try {
-        const { messages: fetchedMessages, next_cursor } = await getRoomMessages(
-          roomId,
-          token,
-          abortController.signal,
-          undefined,
-          INITIAL_HISTORY_PAGE_SIZE,
-        );
-        const history = fetchedMessages.reverse();
-        clearTimeout(timeoutId);
-        if (paginationEpochRef.current !== activeEpoch) {
-          return;
-        }
-
-        // Resolve divider anchor from entry-time history only, so live messages
-        // that arrive while loading cannot retroactively create/move the marker.
-        setNewMessagesAnchorId(
-          findFirstUnreadMessageId(history, lastReadAtSnapshot, user?.id),
-        );
-
-        pendingScrollAdjustmentRef.current = { type: "initial" };
-        setMessages((prev) => {
-          const historyIds = new Set<string | number>(history.map((msg) => msg.id));
-
-          if (history.length === 0) {
-            return history;
-          }
-
-          const newestHistoryMessage = history[history.length - 1];
-          const trueLiveTail = prev.filter((item) => {
-            if ("type" in item) return false;
-            const liveMessage = item as Message;
-            if (historyIds.has(liveMessage.id)) return false;
-            return isStrictlyNewerThan(liveMessage, newestHistoryMessage);
-          }) as Message[];
-
-          const bufferedTail = bufferedContextTail.filter((message) => {
-            if (historyIds.has(message.id)) return false;
-            return isStrictlyNewerThan(message, newestHistoryMessage);
-          });
-
-          const uniqueTailById = new Map<number, Message>();
-          [...trueLiveTail, ...bufferedTail].forEach((message) => {
-            uniqueTailById.set(message.id, message);
-          });
-
-          return [...history, ...Array.from(uniqueTailById.values())];
-        });
-
-        setNextCursor(next_cursor);
-      } catch (err) {
-        clearTimeout(timeoutId);
-        if (err instanceof Error && err.name === "AbortError") {
-          return;
-        }
-        setError(
-          err instanceof Error ? err.message : "Failed to load messages",
-        );
-      } finally {
-        if (!timeoutFiredRef.current) {
-          setLoading(false);
-        }
-      }
-    }
-
-    const deferredId = window.setTimeout(fetchMessages, 0);
-
-    return () => {
-      clearTimeout(deferredId);
-      abortController.abort();
-      if (timeoutId) {
-        clearTimeout(timeoutId);
-      }
-    };
-  }, [roomId, token, retryCount, messageViewMode, lastReadAtSnapshot, user?.id]);
-
-  const handleRetry = () => {
-    setLoading(true);
-    setError("");
-    setIsInitialPositioned(false);
-    setShowJumpToLatest(false);
-    setNewMessagesAnchorId(null);
-    pendingScrollAdjustmentRef.current = null;
-    // Bump local retry counter so the effect above refetches messages
-    setRetryCount((prev) => prev + 1);
-  };
-
-  useEffect(() => {
-    if (highlightedMessageId == null) return;
-
-    const timeoutId = window.setTimeout(() => {
-      setHighlightedMessageId(null);
-    }, 2200);
-
-    return () => clearTimeout(timeoutId);
-  }, [highlightedMessageId]);
-
-  // Load older messages when scrolling to top
-  const loadOlderMessages = useCallback(async () => {
-    if (!token || !nextCursor || isLoadingMore || !isInitialPositioned) return;
-
-    const scrollContainer = scrollContainerRef.current;
-    if (!scrollContainer) return;
-
-    // Record current scroll position before fetching
-    const previousScrollHeight = scrollContainer.scrollHeight;
-    const previousScrollTop = scrollContainer.scrollTop;
-    const { anchorMessageId, anchorTop } = capturePrependAnchor(scrollContainer);
-    const requestEpoch = paginationEpochRef.current;
-
-    setIsLoadingMore(true);
-
-    try {
-      const { messages: olderMessages, next_cursor } = await getRoomMessages(
-        roomId,
-        token,
-        undefined,
-        nextCursor,
-        OLDER_HISTORY_PAGE_SIZE,
-      );
-
-      // Reverse to get oldest-first order (API returns newest-first)
-      const reversedOlderMessages = olderMessages.reverse();
-      if (paginationEpochRef.current !== requestEpoch) {
-        return;
-      }
-
-      pendingScrollAdjustmentRef.current = {
-        type: "prepend",
-        previousScrollHeight,
-        previousScrollTop,
-        anchorMessageId,
-        anchorTop,
-      };
-      setMessages((prev) => {
-        const existingIds = new Set(prev.map((msg) => msg.id));
-        const uniqueOlderMessages = reversedOlderMessages.filter(
-          (msg) => !existingIds.has(msg.id),
-        );
-
-        if (uniqueOlderMessages.length === 0) {
-          pendingScrollAdjustmentRef.current = null;
-          return prev;
-        }
-
-        return [...uniqueOlderMessages, ...prev];
-      });
-
-      // Update cursor
-      setNextCursor(next_cursor);
-    } catch (err) {
-      logError("Failed to load older messages:", err);
-      // Don't show error UI for pagination failures - user can just retry by scrolling
-    } finally {
-      setIsLoadingMore(false);
-    }
-  }, [
-    token,
-    roomId,
-    nextCursor,
+  const {
+    messages,
+    loading,
+    error,
+    retryInitialLoad,
     isLoadingMore,
-    isInitialPositioned,
-    capturePrependAnchor,
-  ]);
-
-  const loadNewerMessages = useCallback(async () => {
-    if (
-      messageViewMode !== "context" ||
-      !token ||
-      !newerCursor ||
-      isLoadingNewer ||
-      !isInitialPositioned
-    ) {
-      return;
-    }
-
-    setIsLoadingNewer(true);
-
-    try {
-      const { messages: newerMessages, next_cursor } = await getRoomMessagesNewer(
-        roomId,
-        token,
-        newerCursor,
-      );
-
-      setMessages((prev) => {
-        const existingIds = new Set(prev.map((msg) => msg.id));
-        const uniqueNewerMessages = newerMessages.filter(
-          (msg) => !existingIds.has(msg.id),
-        );
-
-        if (uniqueNewerMessages.length === 0) {
-          return prev;
-        }
-
-        return [...prev, ...uniqueNewerMessages];
-      });
-      setNewerCursor(next_cursor);
-    } catch (err) {
-      logError("Failed to load newer messages:", err);
-    } finally {
-      setIsLoadingNewer(false);
-    }
-  }, [isInitialPositioned, isLoadingNewer, messageViewMode, newerCursor, roomId, token]);
-
-
-
-  // Append incoming messages (delivered per-message so none are dropped when many arrive quickly)
-  useEffect(() => {
-    if (incomingMessages.length === 0) return;
-
-    if (messageViewMode === "context") {
-      const scrollContainer = scrollContainerRef.current;
-      const contextIsAtLatest =
-        newerCursor === null &&
-        scrollContainer !== null &&
-        isNearBottom(scrollContainer);
-
-      if (contextIsAtLatest) {
-        setMessages((prev) => {
-          const ids = new Set(prev.map((item) => item.id));
-          const toAdd = incomingMessages.filter((m) => !ids.has(m.id));
-          if (toAdd.length === 0) return prev;
-
-          pendingScrollAdjustmentRef.current = { type: "append", behavior: "smooth" };
-          return [...prev, ...toAdd];
-        });
-      } else {
-        setContextLiveMessages((prev) => {
-          const ids = new Set(prev.map((msg) => msg.id));
-          const toAdd = incomingMessages.filter((msg) => !ids.has(msg.id));
-          if (toAdd.length === 0) return prev;
-          return [...prev, ...toAdd];
-        });
-      }
-      onIncomingMessagesProcessed?.();
-      return;
-    }
-
-    const scrollContainer = scrollContainerRef.current;
-    const shouldStickToBottom = scrollContainer ? isNearBottom(scrollContainer) : false;
-
-    setMessages((prev) => {
-      const ids = new Set(prev.map((item) => item.id));
-      const toAdd = incomingMessages.filter((m) => !ids.has(m.id));
-      if (toAdd.length === 0) return prev;
-
-      if (shouldStickToBottom) {
-        pendingScrollAdjustmentRef.current = { type: "append", behavior: "smooth" };
-      }
-
-      return [...prev, ...toAdd];
-    });
-    onIncomingMessagesProcessed?.();
-  }, [
-    incomingMessages,
-    isNearBottom,
-    messageViewMode,
-    newerCursor,
-    onIncomingMessagesProcessed,
-  ]);
-
-  // Sending a local message should always bring the user back to latest chat context.
-  useEffect(() => {
-    if (previousScrollToLatestSignalRef.current === scrollToLatestSignal) return;
-    previousScrollToLatestSignalRef.current = scrollToLatestSignal;
-    if (!isInitialPositioned) return;
-
-    if (messageViewMode === "context") {
-      onExitContextMode?.();
-      return;
-    }
-
-    const container = scrollContainerRef.current;
-    if (!container) return;
-
-    container.scrollTop = container.scrollHeight;
-    setShowJumpToLatest(false);
-  }, [scrollToLatestSignal, isInitialPositioned, messageViewMode, onExitContextMode]);
-
-  useEffect(() => {
-    updateJumpToLatestVisibility();
-  }, [messages, updateJumpToLatestVisibility, messageViewMode]);
-
-  useEffect(() => {
-    if (messageViewMode !== "normal" && messageViewMode !== "context") return;
-
-    const container = scrollContainerRef.current;
-    if (!container || !isInitialPositioned) return;
-
-    const handleScroll = () => {
-      if (jumpVisibilitySuppressedRef.current) {
-        if (isNearBottom(container)) {
-          jumpVisibilitySuppressedRef.current = false;
-        } else {
-          setShowJumpToLatest(false);
-          return;
-        }
-      }
-      updateJumpToLatestVisibility();
-    };
-
-    container.addEventListener("scroll", handleScroll, { passive: true });
-    handleScroll();
-
-    return () => {
-      container.removeEventListener("scroll", handleScroll);
-    };
-  }, [isInitialPositioned, isNearBottom, messageViewMode, updateJumpToLatestVisibility]);
-
-  const handleJumpToLatest = () => {
-    if (messageViewMode === "context") {
-      onExitContextMode?.();
-      return;
-    }
-
-    const container = scrollContainerRef.current;
-    if (!container) return;
-
-    // Keep jump affordance hidden until animated programmatic scroll actually
-    // reaches latest, so long-distance jumps do not flash the button mid-flight.
-    jumpVisibilitySuppressedRef.current = true;
-    container.scrollTo({ top: container.scrollHeight, behavior: "smooth" });
-    setShowJumpToLatest(false);
-  };
-
-  // IntersectionObserver to detect scroll-to-top
-  useEffect(() => {
-    if (!isInitialPositioned) return;
-
-    const sentinel = sentinelRef.current;
-    if (!sentinel) return;
-
-    const observer = new IntersectionObserver(
-      (entries) => {
-        if (entries[0].isIntersecting && nextCursor && !isLoadingMore) {
-          loadOlderMessages();
-        }
-      },
-      {
-        root: scrollContainerRef.current,
-        // Start loading older history well before hard-top so users keep scrolling smoothly.
-        rootMargin: TOP_PREFETCH_ROOT_MARGIN,
-        threshold: 0,
-      }
-    );
-
-    observer.observe(sentinel);
-
-    return () => {
-      observer.disconnect();
-    };
-  }, [nextCursor, isLoadingMore, loadOlderMessages, isInitialPositioned]);
-
-  useEffect(() => {
-    if (!isInitialPositioned || messageViewMode !== "context") return;
-
-    const sentinel = bottomSentinelRef.current;
-    if (!sentinel) return;
-
-    const observer = new IntersectionObserver(
-      (entries) => {
-        if (entries[0].isIntersecting && newerCursor && !isLoadingNewer) {
-          loadNewerMessages();
-        }
-      },
-      {
-        root: scrollContainerRef.current,
-        rootMargin: "100px",
-        threshold: 0,
-      }
-    );
-
-    observer.observe(sentinel);
-
-    return () => {
-      observer.disconnect();
-    };
-  }, [
-    isInitialPositioned,
     isLoadingNewer,
-    loadNewerMessages,
+    nextCursor,
+    newMessagesAnchorId,
+    highlightedMessageId,
+    showJumpToLatest,
+    showContextLiveIndicator,
+    jumpToLatest,
+    scrollContainerRef,
+    sentinelRef,
+    bottomSentinelRef,
+    messagesEndRef,
+  } = useMessageFeedLifecycle({
+    roomId,
+    token,
+    userId: user?.id,
+    density,
     messageViewMode,
-    newerCursor,
-  ]);
-
-  // Message header timestamp: keep compact and time-only.
-  const getMessageTime = (isoString: string) => {
-    const date = new Date(isoString);
-    return date.toLocaleTimeString([], {
-      hour: "numeric",
-      minute: "2-digit",
-    });
-  };
-
-  // Full timestamp used for browser tooltips on hover.
-  const getFullDateTime = (isoString: string) => {
-    const date = new Date(isoString);
-    const longDate = date.toLocaleDateString([], {
-      weekday: "long",
-      month: "long",
-      day: "numeric",
-      year: "numeric",
-    });
-    const time = date.toLocaleTimeString([], {
-      hour: "numeric",
-      minute: "2-digit",
-    });
-    return `${longDate}\n${time}`;
-  };
-
-  // Get date string for date dividers
-  const getDateLabel = (isoString: string) => {
-    const date = new Date(normalizeToUtcIso(isoString));
-    const now = new Date();
-
-    if (date.toDateString() === now.toDateString()) return "TODAY";
-
-    const yesterday = new Date(now);
-    yesterday.setDate(yesterday.getDate() - 1);
-    if (date.toDateString() === yesterday.toDateString()) return "YESTERDAY";
-
-    return date
-      .toLocaleDateString([], { month: "short", day: "numeric", year: "numeric" })
-      .toUpperCase();
-  };
-
-  // Check if a date divider should be shown before this message
-  const shouldShowDateDivider = (current: ChatItem, prev: ChatItem | undefined): boolean => {
-    if (!prev) return true; // Always show for first message
-    if ("type" in current && current.type === "system") return false;
-    if ("type" in prev && prev.type === "system") return false;
-
-    const currMsg = current as Message;
-    const prevMsg = prev as Message;
-    const currDate = new Date(normalizeToUtcIso(currMsg.created_at));
-    const prevDate = new Date(normalizeToUtcIso(prevMsg.created_at));
-
-    return currDate.toDateString() !== prevDate.toDateString();
-  };
-
-  const shouldGroupMessage = (
-    current: ChatItem,
-    prev: ChatItem | undefined,
-  ) => {
-    if (!prev) return false;
-    if ("type" in current && current.type === "system") return false;
-    if ("type" in prev && prev.type === "system") return false;
-
-    const currMsg = current as Message;
-    const prevMsg = prev as Message;
-
-    if (currMsg.username !== prevMsg.username) return false;
-
-    const currTime = new Date(currMsg.created_at).getTime();
-    const prevTime = new Date(prevMsg.created_at).getTime();
-
-    return currTime - prevTime < 5 * 60 * 1000;
-  };
+    messageContext,
+    lastReadAtSnapshot,
+    incomingMessages,
+    onIncomingMessagesProcessed,
+    scrollToLatestSignal,
+    onExitContextMode,
+  });
 
   if (loading && messages.length === 0) {
     return (
@@ -838,7 +83,7 @@ export default function MessageList({
         >
           {error}
           <button
-            onClick={handleRetry}
+            onClick={retryInitialLoad}
             className="mt-2 block w-full py-1 px-2 text-xs transition-colors"
             style={{ background: "rgba(255, 0, 0, 0.1)" }}
           >
@@ -850,8 +95,6 @@ export default function MessageList({
   }
 
   const isComfortableDensity = density === "comfortable";
-  const showContextLiveIndicator =
-    messageViewMode === "context" && contextLiveMessages.length > 0;
   const shouldShowJumpAction = showJumpToLatest || showContextLiveIndicator;
   const jumpActionLabel = showContextLiveIndicator
     ? "New messages available"
@@ -869,10 +112,8 @@ export default function MessageList({
           overflowAnchor: "none",
         }}
       >
-        {/* Sentinel for IntersectionObserver */}
         <div ref={sentinelRef} className="h-px" />
 
-        {/* "Beginning of conversation" marker */}
         {!isLoadingMore && nextCursor == null && (
           <div className="flex justify-center py-4">
             <span
@@ -888,189 +129,16 @@ export default function MessageList({
           </div>
         )}
 
-        {/* Spacer to push messages to bottom when container isn't full */}
         <div className="grow" />
 
-        {messages.map((item, index) => {
-          if ("type" in item && item.type === "system") {
-            return (
-              <div
-                key={item.id}
-                className="flex justify-center my-4 opacity-75 px-4"
-              >
-                <span
-                  className="font-pixel text-[8px] tracking-[0.14em] px-3 py-1"
-                  style={{
-                    color: "var(--color-meta)",
-                    border: "1px solid var(--border-dim)",
-                  }}
-                >
-                  {item.content}
-                </span>
-              </div>
-            );
-          }
+        <MessageFeedContent
+          messages={messages}
+          density={density}
+          theme={theme}
+          newMessagesAnchorId={newMessagesAnchorId}
+          highlightedMessageId={highlightedMessageId}
+        />
 
-          const message = item as Message;
-          const isoDate = normalizeToUtcIso(message.created_at);
-          const isGrouped = shouldGroupMessage(item, messages[index - 1]);
-          const showDateDivider = shouldShowDateDivider(item, messages[index - 1]);
-          // Keep amber visuals cohesive by using per-user hues only in neon mode.
-          const userColors =
-            theme === "neon" ? getUserColorPalette(message.username) : null;
-
-          const headerTime = getMessageTime(isoDate);
-          const hoverTime = new Date(isoDate).toLocaleTimeString([], {
-            hour: "numeric",
-            minute: "2-digit",
-          });
-          const fullDateTime = getFullDateTime(isoDate);
-
-          return (
-            <div key={message.id}>
-              {newMessagesAnchorId === message.id && (
-                <div
-                  className={`flex items-center ${isComfortableDensity ? "gap-3 my-6" : "gap-2.5 my-5"}`}
-                >
-                  <div
-                    className="flex-1 h-px"
-                    style={{
-                      background:
-                        "linear-gradient(90deg, transparent, var(--color-secondary))",
-                    }}
-                  />
-                  <span
-                    className="font-pixel text-[8px] tracking-[0.16em] px-2 py-1"
-                    style={{
-                      color: "var(--color-secondary)",
-                      border: "1px solid var(--color-secondary)",
-                    }}
-                  >
-                    NEW MESSAGES
-                  </span>
-                  <div
-                    className="flex-1 h-px"
-                    style={{
-                      background:
-                        "linear-gradient(270deg, transparent, var(--color-secondary))",
-                    }}
-                  />
-                </div>
-              )}
-
-              {/* Date divider */}
-              {showDateDivider && (
-                <div
-                  className={`flex items-center ${isComfortableDensity ? "gap-3 my-6" : "gap-2.5 my-5"}`}
-                >
-                  <div className="flex-1 h-px" style={{ background: "linear-gradient(90deg, transparent, var(--border-dim))" }} />
-                  <span
-                    className="font-pixel text-[8px] tracking-[0.16em]"
-                    style={{ color: "var(--color-text)" }}
-                  >
-                    {getDateLabel(isoDate)}
-                  </span>
-                  <div className="flex-1 h-px" style={{ background: "linear-gradient(270deg, transparent, var(--border-dim))" }} />
-                </div>
-              )}
-
-              {/* Flush-left message row (Discord-style) */}
-              <div
-                data-chat-message="true"
-                data-message-id={message.id}
-                className={`group flex items-start hover:bg-white/[0.02] transition-colors ${
-                  isComfortableDensity ? "gap-3 px-2" : "gap-2.5 px-1.5"
-                } ${
-                  isGrouped
-                    ? isComfortableDensity
-                      ? "mt-0.5 py-0.5"
-                      : "mt-0 py-0.5"
-                    : isComfortableDensity
-                      ? "mt-3.5 py-0.5"
-                      : "mt-2.5 py-0.5"
-                }`}
-                style={{
-                  animation: "slide-in 0.2s ease-out",
-                  background:
-                    highlightedMessageId === message.id
-                      ? "rgba(0, 240, 255, 0.10)"
-                      : undefined,
-                  borderLeft:
-                    highlightedMessageId === message.id
-                      ? "2px solid var(--color-primary)"
-                      : "2px solid transparent",
-                }}
-              >
-                {/* Left: avatar or hover timestamp */}
-                <div
-                  className={`shrink-0 select-none flex justify-center ${
-                    isComfortableDensity ? "w-11" : "w-9"
-                  }`}
-                >
-                  {!isGrouped ? (
-                    <div
-                      className={`rounded-full flex items-center justify-center font-bebas ${
-                        isComfortableDensity ? "w-11 h-11 text-[16px]" : "w-9 h-9 text-[14px]"
-                      }`}
-                      style={{
-                        background: userColors?.backgroundColor ?? "var(--bg-app)",
-                        border: `1px solid ${userColors?.borderColor ?? "var(--border-primary)"}`,
-                        color: userColors?.textColor ?? "var(--color-primary)",
-                        boxShadow: userColors?.glowColor ?? "none",
-                      }}
-                    >
-                      {message.username.substring(0, 2).toUpperCase()}
-                    </div>
-                  ) : (
-                    <span
-                      className={`block font-mono pt-1 text-center w-full whitespace-nowrap opacity-0 group-hover:opacity-100 transition-opacity duration-150 ${
-                        isComfortableDensity ? "text-[12px]" : "text-[11px]"
-                      }`}
-                      style={{ color: "var(--color-meta)" }}
-                      title={fullDateTime}
-                    >
-                      {hoverTime}
-                    </span>
-                  )}
-                </div>
-
-                {/* Right: meta + content */}
-                <div className="flex flex-col min-w-0 flex-1">
-                  {!isGrouped && (
-                    <div className="flex items-baseline gap-2">
-                      <span
-                        className="font-mono font-semibold text-[14px] tracking-[0.06em]"
-                        style={{ color: userColors?.textColor ?? "var(--color-primary)" }}
-                      >
-                        {message.username}
-                      </span>
-                      <span
-                        className={`font-mono tracking-[0.08em] ${
-                          isComfortableDensity ? "text-[12px]" : "text-[11px]"
-                        }`}
-                        style={{ color: "var(--color-meta)" }}
-                        title={fullDateTime}
-                      >
-                        {headerTime}
-                      </span>
-                    </div>
-                  )}
-
-                  <div
-                    className={`font-mono break-words ${
-                      isComfortableDensity
-                        ? "text-[18px] leading-relaxed"
-                        : "text-[15px] leading-normal"
-                    } ${isGrouped ? "" : isComfortableDensity ? "mt-1" : "mt-0.5"}`}
-                    style={{ color: "var(--color-msg-text)" }}
-                  >
-                    {message.content}
-                  </div>
-                </div>
-              </div>
-            </div>
-          );
-        })}
         {isLoadingNewer && (
           <div className="flex justify-center py-4">
             <span className="font-mono text-[11px]" style={{ color: "var(--color-meta)" }}>
@@ -1078,6 +146,7 @@ export default function MessageList({
             </span>
           </div>
         )}
+
         <div ref={bottomSentinelRef} className="h-px" />
         <div ref={messagesEndRef} />
       </div>
@@ -1100,7 +169,7 @@ export default function MessageList({
       {shouldShowJumpAction && (
         <button
           type="button"
-          onClick={handleJumpToLatest}
+          onClick={jumpToLatest}
           className="absolute bottom-4 right-4 z-10 px-3 py-2 font-bebas text-[14px] tracking-[0.10em] shadow-lg transition-colors"
           style={{
             background: "var(--color-primary)",

--- a/frontend/src/components/__tests__/MessageList.test.tsx
+++ b/frontend/src/components/__tests__/MessageList.test.tsx
@@ -159,6 +159,26 @@ describe("MessageList", () => {
     expect(screen.getByText("BEGINNING OF CONVERSATION")).toBeInTheDocument();
   });
 
+  it("keeps message row data attributes for scroll anchors", async () => {
+    const oldest = makeMessage({
+      id: 41,
+      username: "alice",
+      content: "Anchor message",
+      createdAt: "2024-01-01T10:00:00Z",
+    });
+
+    mockGetRoomMessages.mockResolvedValueOnce({
+      messages: [oldest],
+      next_cursor: null,
+    });
+    const { container } = renderMessageList();
+
+    await screen.findByText("Anchor message");
+    const row = container.querySelector<HTMLElement>("[data-chat-message='true']");
+    expect(row).not.toBeNull();
+    expect(row?.getAttribute("data-message-id")).toBe("41");
+  });
+
   it("shows TODAY and older date divider labels", async () => {
     const now = new Date();
     const todayIso = now.toISOString();
@@ -252,6 +272,54 @@ describe("MessageList", () => {
 
     await screen.findByText("Incoming");
     expect(screen.getAllByText("Initial")).toHaveLength(1);
+    expect(mockOnIncomingMessagesProcessed).toHaveBeenCalledTimes(1);
+  });
+
+  it("buffers context incoming messages without duplicating already-rendered rows", async () => {
+    const contextBase = makeMessage({
+      id: 5,
+      username: "alice",
+      content: "Context base",
+      createdAt: "2024-01-01T10:00:00Z",
+    });
+    const incomingNew = makeMessage({
+      id: 6,
+      username: "bob",
+      content: "Context incoming",
+      createdAt: "2024-01-01T10:01:00Z",
+    });
+
+    const { rerender } = renderMessageList({
+      messageViewMode: "context",
+      messageContext: {
+        messages: [contextBase],
+        target_message_id: contextBase.id,
+        older_cursor: null,
+        newer_cursor: "newer-1",
+      },
+    });
+
+    await screen.findByText("Context base");
+
+    rerender(
+      <MessageList
+        roomId={1}
+        density="compact"
+        messageViewMode="context"
+        messageContext={{
+          messages: [contextBase],
+          target_message_id: contextBase.id,
+          older_cursor: null,
+          newer_cursor: "newer-1",
+        }}
+        incomingMessages={[contextBase, incomingNew]}
+        onIncomingMessagesProcessed={mockOnIncomingMessagesProcessed}
+        scrollToLatestSignal={0}
+      />,
+    );
+
+    expect(await screen.findByRole("button", { name: "New messages available" })).toBeInTheDocument();
+    expect(screen.getAllByText("Context base")).toHaveLength(1);
     expect(mockOnIncomingMessagesProcessed).toHaveBeenCalledTimes(1);
   });
 

--- a/frontend/src/components/message-list/MessageFeedContent.tsx
+++ b/frontend/src/components/message-list/MessageFeedContent.tsx
@@ -1,0 +1,137 @@
+import type { Message } from "../../types";
+import {
+  getDateLabel,
+  getFullDateTime,
+  getMessageTime,
+  normalizeToUtcIso,
+  shouldGroupMessage,
+  shouldShowDateDivider,
+  type ChatItem,
+} from "./messageListFormatting";
+import { MessageRow } from "./MessageRow";
+
+interface MessageFeedContentProps {
+  messages: ChatItem[];
+  density: "compact" | "comfortable";
+  theme: "neon" | "amber";
+  newMessagesAnchorId: number | null;
+  highlightedMessageId: number | null;
+}
+
+export function MessageFeedContent({
+  messages,
+  density,
+  theme,
+  newMessagesAnchorId,
+  highlightedMessageId,
+}: MessageFeedContentProps) {
+  const isComfortableDensity = density === "comfortable";
+
+  return (
+    <>
+      {messages.map((item, index) => {
+        if ("type" in item && item.type === "system") {
+          return (
+            <div
+              key={item.id}
+              className="flex justify-center my-4 opacity-75 px-4"
+            >
+              <span
+                className="font-pixel text-[8px] tracking-[0.14em] px-3 py-1"
+                style={{
+                  color: "var(--color-meta)",
+                  border: "1px solid var(--border-dim)",
+                }}
+              >
+                {item.content}
+              </span>
+            </div>
+          );
+        }
+
+        const message = item as Message;
+        const isoDate = normalizeToUtcIso(message.created_at);
+        const isGrouped = shouldGroupMessage(item, messages[index - 1]);
+        const showDateDivider = shouldShowDateDivider(item, messages[index - 1]);
+        const headerTime = getMessageTime(isoDate);
+        const hoverTime = new Date(isoDate).toLocaleTimeString([], {
+          hour: "numeric",
+          minute: "2-digit",
+        });
+        const fullDateTime = getFullDateTime(isoDate);
+
+        return (
+          <div key={message.id}>
+            {newMessagesAnchorId === message.id && (
+              <div
+                className={`flex items-center ${isComfortableDensity ? "gap-3 my-6" : "gap-2.5 my-5"}`}
+              >
+                <div
+                  className="flex-1 h-px"
+                  style={{
+                    background:
+                      "linear-gradient(90deg, transparent, var(--color-secondary))",
+                  }}
+                />
+                <span
+                  className="font-pixel text-[8px] tracking-[0.16em] px-2 py-1"
+                  style={{
+                    color: "var(--color-secondary)",
+                    border: "1px solid var(--color-secondary)",
+                  }}
+                >
+                  NEW MESSAGES
+                </span>
+                <div
+                  className="flex-1 h-px"
+                  style={{
+                    background:
+                      "linear-gradient(270deg, transparent, var(--color-secondary))",
+                  }}
+                />
+              </div>
+            )}
+
+            {showDateDivider && (
+              <div
+                className={`flex items-center ${isComfortableDensity ? "gap-3 my-6" : "gap-2.5 my-5"}`}
+              >
+                <div
+                  className="flex-1 h-px"
+                  style={{
+                    background:
+                      "linear-gradient(90deg, transparent, var(--border-dim))",
+                  }}
+                />
+                <span
+                  className="font-pixel text-[8px] tracking-[0.16em]"
+                  style={{ color: "var(--color-text)" }}
+                >
+                  {getDateLabel(isoDate)}
+                </span>
+                <div
+                  className="flex-1 h-px"
+                  style={{
+                    background:
+                      "linear-gradient(270deg, transparent, var(--border-dim))",
+                  }}
+                />
+              </div>
+            )}
+
+            <MessageRow
+              message={message}
+              isGrouped={isGrouped}
+              isComfortableDensity={isComfortableDensity}
+              theme={theme}
+              isHighlighted={highlightedMessageId === message.id}
+              headerTime={headerTime}
+              hoverTime={hoverTime}
+              fullDateTime={fullDateTime}
+            />
+          </div>
+        );
+      })}
+    </>
+  );
+}

--- a/frontend/src/components/message-list/MessageRow.tsx
+++ b/frontend/src/components/message-list/MessageRow.tsx
@@ -1,0 +1,117 @@
+import { getUserColorPalette } from "../../utils/userColors";
+import type { Message } from "../../types";
+
+interface MessageRowProps {
+  message: Message;
+  isGrouped: boolean;
+  isComfortableDensity: boolean;
+  theme: "neon" | "amber";
+  isHighlighted: boolean;
+  headerTime: string;
+  hoverTime: string;
+  fullDateTime: string;
+}
+
+export function MessageRow({
+  message,
+  isGrouped,
+  isComfortableDensity,
+  theme,
+  isHighlighted,
+  headerTime,
+  hoverTime,
+  fullDateTime,
+}: MessageRowProps) {
+  // Keep amber visuals cohesive by using per-user hues only in neon mode.
+  const userColors = theme === "neon" ? getUserColorPalette(message.username) : null;
+
+  return (
+    <div
+      data-chat-message="true"
+      data-message-id={message.id}
+      className={`group flex items-start hover:bg-white/[0.02] transition-colors ${
+        isComfortableDensity ? "gap-3 px-2" : "gap-2.5 px-1.5"
+      } ${
+        isGrouped
+          ? isComfortableDensity
+            ? "mt-0.5 py-0.5"
+            : "mt-0 py-0.5"
+          : isComfortableDensity
+            ? "mt-3.5 py-0.5"
+            : "mt-2.5 py-0.5"
+      }`}
+      style={{
+        animation: "slide-in 0.2s ease-out",
+        background: isHighlighted ? "rgba(0, 240, 255, 0.10)" : undefined,
+        borderLeft: isHighlighted
+          ? "2px solid var(--color-primary)"
+          : "2px solid transparent",
+      }}
+    >
+      <div
+        className={`shrink-0 select-none flex justify-center ${
+          isComfortableDensity ? "w-11" : "w-9"
+        }`}
+      >
+        {!isGrouped ? (
+          <div
+            className={`rounded-full flex items-center justify-center font-bebas ${
+              isComfortableDensity ? "w-11 h-11 text-[16px]" : "w-9 h-9 text-[14px]"
+            }`}
+            style={{
+              background: userColors?.backgroundColor ?? "var(--bg-app)",
+              border: `1px solid ${userColors?.borderColor ?? "var(--border-primary)"}`,
+              color: userColors?.textColor ?? "var(--color-primary)",
+              boxShadow: userColors?.glowColor ?? "none",
+            }}
+          >
+            {message.username.substring(0, 2).toUpperCase()}
+          </div>
+        ) : (
+          <span
+            className={`block font-mono pt-1 text-center w-full whitespace-nowrap opacity-0 group-hover:opacity-100 transition-opacity duration-150 ${
+              isComfortableDensity ? "text-[12px]" : "text-[11px]"
+            }`}
+            style={{ color: "var(--color-meta)" }}
+            title={fullDateTime}
+          >
+            {hoverTime}
+          </span>
+        )}
+      </div>
+
+      <div className="flex flex-col min-w-0 flex-1">
+        {!isGrouped && (
+          <div className="flex items-baseline gap-2">
+            <span
+              className="font-mono font-semibold text-[14px] tracking-[0.06em]"
+              style={{ color: userColors?.textColor ?? "var(--color-primary)" }}
+            >
+              {message.username}
+            </span>
+            <span
+              className={`font-mono tracking-[0.08em] ${
+                isComfortableDensity ? "text-[12px]" : "text-[11px]"
+              }`}
+              style={{ color: "var(--color-meta)" }}
+              title={fullDateTime}
+            >
+              {headerTime}
+            </span>
+          </div>
+        )}
+
+        <div
+          className={`font-mono break-words ${
+            isComfortableDensity
+              ? "text-[18px] leading-relaxed"
+              : "text-[15px] leading-normal"
+          } ${isGrouped ? "" : isComfortableDensity ? "mt-1" : "mt-0.5"}`}
+          style={{ color: "var(--color-msg-text)" }}
+        >
+          {message.content}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/message-list/messageListFormatting.ts
+++ b/frontend/src/components/message-list/messageListFormatting.ts
@@ -1,0 +1,168 @@
+import type { Message } from "../../types";
+
+export interface SystemMessage {
+  id: string;
+  type: "system";
+  content: string;
+  timestamp: number;
+}
+
+export type ChatItem = Message | SystemMessage;
+
+export function normalizeToUtcIso(isoString: string): string {
+  const hasTimezoneSuffix = /(?:Z|[+-]\d{2}:\d{2})$/i.test(isoString);
+  return hasTimezoneSuffix ? isoString : `${isoString}Z`;
+}
+
+export function parseTimestamp(isoString: string | null | undefined): number | null {
+  if (!isoString) return null;
+  const timestamp = Date.parse(normalizeToUtcIso(isoString));
+  return Number.isNaN(timestamp) ? null : timestamp;
+}
+
+export function isStrictlyNewerThan(
+  candidate: Message,
+  reference: Message,
+): boolean {
+  const candidateTime = parseTimestamp(candidate.created_at);
+  const referenceTime = parseTimestamp(reference.created_at);
+
+  if (
+    candidateTime != null &&
+    referenceTime != null &&
+    candidateTime !== referenceTime
+  ) {
+    return candidateTime > referenceTime;
+  }
+
+  if (candidateTime != null && referenceTime == null) return true;
+  if (candidateTime == null && referenceTime != null) return false;
+
+  return candidate.id > reference.id;
+}
+
+export function findFirstUnreadMessageId(
+  items: ChatItem[],
+  snapshot: string | null | undefined,
+  currentUserId: number | null | undefined,
+): number | null {
+  const snapshotTimestamp = parseTimestamp(snapshot);
+  if (snapshotTimestamp == null) return null;
+
+  const unreadMessage = items.find((item) => {
+    if ("type" in item && item.type === "system") return false;
+    if (currentUserId != null && (item as Message).user_id === currentUserId) {
+      return false;
+    }
+    const messageTimestamp = parseTimestamp((item as Message).created_at);
+    return messageTimestamp != null && messageTimestamp > snapshotTimestamp;
+  });
+
+  if (!unreadMessage || ("type" in unreadMessage && unreadMessage.type === "system")) {
+    return null;
+  }
+
+  return (unreadMessage as Message).id;
+}
+
+export function getMessageTime(isoString: string): string {
+  const date = new Date(isoString);
+  return date.toLocaleTimeString([], {
+    hour: "numeric",
+    minute: "2-digit",
+  });
+}
+
+export function getFullDateTime(isoString: string): string {
+  const date = new Date(isoString);
+  const longDate = date.toLocaleDateString([], {
+    weekday: "long",
+    month: "long",
+    day: "numeric",
+    year: "numeric",
+  });
+  const time = date.toLocaleTimeString([], {
+    hour: "numeric",
+    minute: "2-digit",
+  });
+  return `${longDate}\n${time}`;
+}
+
+export function getDateLabel(isoString: string): string {
+  const date = new Date(normalizeToUtcIso(isoString));
+  const now = new Date();
+
+  if (date.toDateString() === now.toDateString()) return "TODAY";
+
+  const yesterday = new Date(now);
+  yesterday.setDate(yesterday.getDate() - 1);
+  if (date.toDateString() === yesterday.toDateString()) return "YESTERDAY";
+
+  return date
+    .toLocaleDateString([], { month: "short", day: "numeric", year: "numeric" })
+    .toUpperCase();
+}
+
+export function shouldShowDateDivider(
+  current: ChatItem,
+  prev: ChatItem | undefined,
+): boolean {
+  if (!prev) return true;
+  if ("type" in current && current.type === "system") return false;
+  if ("type" in prev && prev.type === "system") return false;
+
+  const currMsg = current as Message;
+  const prevMsg = prev as Message;
+  const currDate = new Date(normalizeToUtcIso(currMsg.created_at));
+  const prevDate = new Date(normalizeToUtcIso(prevMsg.created_at));
+
+  return currDate.toDateString() !== prevDate.toDateString();
+}
+
+export function shouldGroupMessage(
+  current: ChatItem,
+  prev: ChatItem | undefined,
+): boolean {
+  if (!prev) return false;
+  if ("type" in current && current.type === "system") return false;
+  if ("type" in prev && prev.type === "system") return false;
+
+  const currMsg = current as Message;
+  const prevMsg = prev as Message;
+
+  if (currMsg.username !== prevMsg.username) return false;
+
+  const currTime = new Date(currMsg.created_at).getTime();
+  const prevTime = new Date(prevMsg.created_at).getTime();
+
+  return currTime - prevTime < 5 * 60 * 1000;
+}
+
+export function capturePrependAnchor(
+  container: HTMLDivElement,
+): { anchorMessageId: number | null; anchorTop: number | null } {
+  const containerTop = container.getBoundingClientRect().top;
+  const messageElements = Array.from(
+    container.querySelectorAll<HTMLElement>("[data-chat-message='true'][data-message-id]"),
+  );
+
+  const anchorElement =
+    messageElements.find(
+      (el) => el.getBoundingClientRect().bottom >= containerTop,
+    ) ?? messageElements[0];
+
+  if (!anchorElement) {
+    return { anchorMessageId: null, anchorTop: null };
+  }
+
+  const rawId = anchorElement.dataset.messageId;
+  const parsedId = rawId ? Number(rawId) : Number.NaN;
+  if (!Number.isFinite(parsedId)) {
+    return { anchorMessageId: null, anchorTop: null };
+  }
+
+  return {
+    anchorMessageId: parsedId,
+    anchorTop: anchorElement.getBoundingClientRect().top,
+  };
+}

--- a/frontend/src/hooks/useMessageFeedLifecycle.ts
+++ b/frontend/src/hooks/useMessageFeedLifecycle.ts
@@ -1,0 +1,448 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import type { RefObject } from "react";
+import { getRoomMessages, getRoomMessagesNewer } from "../services/api";
+import { logError } from "../utils/logger";
+import type { Message, MessageContextResponse } from "../types";
+import {
+  capturePrependAnchor,
+  findFirstUnreadMessageId,
+  isStrictlyNewerThan,
+  type ChatItem,
+} from "../components/message-list/messageListFormatting";
+import {
+  useMessageFeedViewport,
+  type PendingScrollAdjustment,
+} from "./useMessageFeedViewport";
+
+interface UseMessageFeedLifecycleParams {
+  roomId: number;
+  token: string | null;
+  userId: number | null | undefined;
+  density: "compact" | "comfortable";
+  messageViewMode: "normal" | "context";
+  messageContext: MessageContextResponse | null;
+  lastReadAtSnapshot: string | null;
+  incomingMessages: Message[];
+  onIncomingMessagesProcessed?: () => void;
+  scrollToLatestSignal: number;
+  onExitContextMode?: () => void;
+}
+
+interface UseMessageFeedLifecycleResult {
+  messages: ChatItem[];
+  loading: boolean;
+  error: string;
+  retryInitialLoad: () => void;
+  isLoadingMore: boolean;
+  isLoadingNewer: boolean;
+  nextCursor: string | null;
+  newMessagesAnchorId: number | null;
+  highlightedMessageId: number | null;
+  showJumpToLatest: boolean;
+  showContextLiveIndicator: boolean;
+  jumpToLatest: () => void;
+  scrollContainerRef: RefObject<HTMLDivElement | null>;
+  sentinelRef: RefObject<HTMLDivElement | null>;
+  bottomSentinelRef: RefObject<HTMLDivElement | null>;
+  messagesEndRef: RefObject<HTMLDivElement | null>;
+}
+
+const INITIAL_HISTORY_PAGE_SIZE = 75;
+const OLDER_HISTORY_PAGE_SIZE = 100;
+const MESSAGES_LOAD_TIMEOUT_MS = 5000;
+
+export function useMessageFeedLifecycle({
+  roomId,
+  token,
+  userId,
+  density,
+  messageViewMode,
+  messageContext,
+  lastReadAtSnapshot,
+  incomingMessages,
+  onIncomingMessagesProcessed,
+  scrollToLatestSignal,
+  onExitContextMode,
+}: UseMessageFeedLifecycleParams): UseMessageFeedLifecycleResult {
+  const [messages, setMessages] = useState<ChatItem[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState("");
+  const [retryCount, setRetryCount] = useState(0);
+  const [nextCursor, setNextCursor] = useState<string | null>(null);
+  const [newerCursor, setNewerCursor] = useState<string | null>(null);
+  const [isLoadingMore, setIsLoadingMore] = useState(false);
+  const [isLoadingNewer, setIsLoadingNewer] = useState(false);
+  const [isInitialPositioned, setIsInitialPositioned] = useState(false);
+  const [showJumpToLatest, setShowJumpToLatest] = useState(false);
+  const [highlightedMessageId, setHighlightedMessageId] = useState<number | null>(null);
+  const [contextLiveMessages, setContextLiveMessages] = useState<Message[]>([]);
+  /**
+   * Divider anchor is resolved once per room-entry so the "NEW MESSAGES"
+   * marker does not reposition while the user keeps viewing this room.
+   */
+  const [newMessagesAnchorId, setNewMessagesAnchorId] = useState<number | null>(null);
+
+  const messagesEndRef = useRef<HTMLDivElement>(null);
+  const scrollContainerRef = useRef<HTMLDivElement>(null);
+  const sentinelRef = useRef<HTMLDivElement>(null);
+  const bottomSentinelRef = useRef<HTMLDivElement>(null);
+  const pendingScrollAdjustmentRef = useRef<PendingScrollAdjustment | null>(null);
+  const timeoutFiredRef = useRef(false);
+  const contextLiveMessagesRef = useRef<Message[]>([]);
+  const paginationEpochRef = useRef(0);
+
+  useEffect(() => {
+    contextLiveMessagesRef.current = contextLiveMessages;
+  }, [contextLiveMessages]);
+
+  useEffect(() => {
+    if (messageViewMode !== "context" || !messageContext) return;
+
+    paginationEpochRef.current += 1;
+    setError("");
+    setLoading(false);
+    setIsInitialPositioned(false);
+    setShowJumpToLatest(false);
+    setContextLiveMessages([]);
+    setNextCursor(messageContext.older_cursor);
+    setNewerCursor(messageContext.newer_cursor);
+    setHighlightedMessageId(messageContext.target_message_id);
+    pendingScrollAdjustmentRef.current = {
+      type: "context-target",
+      targetMessageId: messageContext.target_message_id,
+    };
+    setMessages(messageContext.messages);
+  }, [messageContext, messageViewMode]);
+
+  // Fetch history when room changes in normal mode. Defer fetch to next tick so
+  // React Strict Mode cleanup runs before the first fetch starts.
+  useEffect(() => {
+    if (messageViewMode !== "normal") return;
+
+    const abortController = new AbortController();
+    let timeoutId: number | undefined;
+    const bufferedContextTail = contextLiveMessagesRef.current;
+
+    if (token) {
+      paginationEpochRef.current += 1;
+      setError("");
+      setLoading(true);
+      setNextCursor(null);
+      setNewerCursor(null);
+      setContextLiveMessages([]);
+      setHighlightedMessageId(null);
+      setIsInitialPositioned(false);
+      setShowJumpToLatest(false);
+      setNewMessagesAnchorId(null);
+      pendingScrollAdjustmentRef.current = null;
+    }
+    const activeEpoch = paginationEpochRef.current;
+
+    async function fetchMessages() {
+      if (!token) return;
+
+      timeoutFiredRef.current = false;
+
+      timeoutId = window.setTimeout(() => {
+        timeoutFiredRef.current = true;
+        setError("Loading messages is taking longer than expected. The server may be waking up.");
+        setLoading(false);
+      }, MESSAGES_LOAD_TIMEOUT_MS);
+
+      try {
+        const { messages: fetchedMessages, next_cursor } = await getRoomMessages(
+          roomId,
+          token,
+          abortController.signal,
+          undefined,
+          INITIAL_HISTORY_PAGE_SIZE,
+        );
+        const history = fetchedMessages.reverse();
+        clearTimeout(timeoutId);
+        if (paginationEpochRef.current !== activeEpoch) {
+          return;
+        }
+
+        // Resolve divider anchor from entry-time history only, so live messages
+        // that arrive while loading cannot retroactively create/move the marker.
+        setNewMessagesAnchorId(
+          findFirstUnreadMessageId(history, lastReadAtSnapshot, userId),
+        );
+
+        pendingScrollAdjustmentRef.current = { type: "initial" };
+        setMessages((prev) => {
+          const historyIds = new Set<string | number>(history.map((msg) => msg.id));
+
+          if (history.length === 0) {
+            return history;
+          }
+
+          const newestHistoryMessage = history[history.length - 1];
+          const trueLiveTail = prev.filter((item) => {
+            if ("type" in item) return false;
+            const liveMessage = item as Message;
+            if (historyIds.has(liveMessage.id)) return false;
+            return isStrictlyNewerThan(liveMessage, newestHistoryMessage);
+          }) as Message[];
+
+          const bufferedTail = bufferedContextTail.filter((message) => {
+            if (historyIds.has(message.id)) return false;
+            return isStrictlyNewerThan(message, newestHistoryMessage);
+          });
+
+          const uniqueTailById = new Map<number, Message>();
+          [...trueLiveTail, ...bufferedTail].forEach((message) => {
+            uniqueTailById.set(message.id, message);
+          });
+
+          return [...history, ...Array.from(uniqueTailById.values())];
+        });
+
+        setNextCursor(next_cursor);
+      } catch (err) {
+        clearTimeout(timeoutId);
+        if (err instanceof Error && err.name === "AbortError") {
+          return;
+        }
+        setError(
+          err instanceof Error ? err.message : "Failed to load messages",
+        );
+      } finally {
+        if (!timeoutFiredRef.current) {
+          setLoading(false);
+        }
+      }
+    }
+
+    const deferredId = window.setTimeout(fetchMessages, 0);
+
+    return () => {
+      clearTimeout(deferredId);
+      abortController.abort();
+      if (timeoutId) {
+        clearTimeout(timeoutId);
+      }
+    };
+  }, [roomId, token, retryCount, messageViewMode, lastReadAtSnapshot, userId]);
+
+  const retryInitialLoad = useCallback(() => {
+    setLoading(true);
+    setError("");
+    setIsInitialPositioned(false);
+    setShowJumpToLatest(false);
+    setNewMessagesAnchorId(null);
+    pendingScrollAdjustmentRef.current = null;
+    setRetryCount((prev) => prev + 1);
+  }, []);
+
+  useEffect(() => {
+    if (highlightedMessageId == null) return;
+
+    const timeoutId = window.setTimeout(() => {
+      setHighlightedMessageId(null);
+    }, 2200);
+
+    return () => clearTimeout(timeoutId);
+  }, [highlightedMessageId]);
+
+  const loadOlderMessages = useCallback(async () => {
+    if (!token || !nextCursor || isLoadingMore || !isInitialPositioned) return;
+
+    const scrollContainer = scrollContainerRef.current;
+    if (!scrollContainer) return;
+
+    const previousScrollHeight = scrollContainer.scrollHeight;
+    const previousScrollTop = scrollContainer.scrollTop;
+    const { anchorMessageId, anchorTop } = capturePrependAnchor(scrollContainer);
+    const requestEpoch = paginationEpochRef.current;
+
+    setIsLoadingMore(true);
+
+    try {
+      const { messages: olderMessages, next_cursor } = await getRoomMessages(
+        roomId,
+        token,
+        undefined,
+        nextCursor,
+        OLDER_HISTORY_PAGE_SIZE,
+      );
+
+      const reversedOlderMessages = olderMessages.reverse();
+      if (paginationEpochRef.current !== requestEpoch) {
+        return;
+      }
+
+      pendingScrollAdjustmentRef.current = {
+        type: "prepend",
+        previousScrollHeight,
+        previousScrollTop,
+        anchorMessageId,
+        anchorTop,
+      };
+      setMessages((prev) => {
+        const existingIds = new Set(prev.map((msg) => msg.id));
+        const uniqueOlderMessages = reversedOlderMessages.filter(
+          (msg) => !existingIds.has(msg.id),
+        );
+
+        if (uniqueOlderMessages.length === 0) {
+          pendingScrollAdjustmentRef.current = null;
+          return prev;
+        }
+
+        return [...uniqueOlderMessages, ...prev];
+      });
+
+      setNextCursor(next_cursor);
+    } catch (err) {
+      logError("Failed to load older messages:", err);
+    } finally {
+      setIsLoadingMore(false);
+    }
+  }, [
+    token,
+    roomId,
+    nextCursor,
+    isLoadingMore,
+    isInitialPositioned,
+  ]);
+
+  const loadNewerMessages = useCallback(async () => {
+    if (
+      messageViewMode !== "context" ||
+      !token ||
+      !newerCursor ||
+      isLoadingNewer ||
+      !isInitialPositioned
+    ) {
+      return;
+    }
+
+    setIsLoadingNewer(true);
+
+    try {
+      const { messages: newerMessages, next_cursor } = await getRoomMessagesNewer(
+        roomId,
+        token,
+        newerCursor,
+      );
+
+      setMessages((prev) => {
+        const existingIds = new Set(prev.map((msg) => msg.id));
+        const uniqueNewerMessages = newerMessages.filter(
+          (msg) => !existingIds.has(msg.id),
+        );
+
+        if (uniqueNewerMessages.length === 0) {
+          return prev;
+        }
+
+        return [...prev, ...uniqueNewerMessages];
+      });
+      setNewerCursor(next_cursor);
+    } catch (err) {
+      logError("Failed to load newer messages:", err);
+    } finally {
+      setIsLoadingNewer(false);
+    }
+  }, [isInitialPositioned, isLoadingNewer, messageViewMode, newerCursor, roomId, token]);
+
+  const { isNearBottom, jumpToLatest } = useMessageFeedViewport({
+    density,
+    messageViewMode,
+    messages,
+    nextCursor,
+    newerCursor,
+    isLoadingMore,
+    isLoadingNewer,
+    isInitialPositioned,
+    setIsInitialPositioned,
+    setShowJumpToLatest,
+    scrollToLatestSignal,
+    onExitContextMode,
+    loadOlderMessages,
+    loadNewerMessages,
+    scrollContainerRef,
+    sentinelRef,
+    bottomSentinelRef,
+    messagesEndRef,
+    pendingScrollAdjustmentRef,
+  });
+
+  // Append incoming messages (delivered per-message so none are dropped when many arrive quickly)
+  useEffect(() => {
+    if (incomingMessages.length === 0) return;
+
+    if (messageViewMode === "context") {
+      const scrollContainer = scrollContainerRef.current;
+      const contextIsAtLatest =
+        newerCursor === null &&
+        scrollContainer !== null &&
+        isNearBottom(scrollContainer);
+
+      if (contextIsAtLatest) {
+        setMessages((prev) => {
+          const ids = new Set(prev.map((item) => item.id));
+          const toAdd = incomingMessages.filter((m) => !ids.has(m.id));
+          if (toAdd.length === 0) return prev;
+
+          pendingScrollAdjustmentRef.current = { type: "append", behavior: "smooth" };
+          return [...prev, ...toAdd];
+        });
+      } else {
+        setContextLiveMessages((prev) => {
+          const ids = new Set(prev.map((msg) => msg.id));
+          const toAdd = incomingMessages.filter((msg) => !ids.has(msg.id));
+          if (toAdd.length === 0) return prev;
+          return [...prev, ...toAdd];
+        });
+      }
+      onIncomingMessagesProcessed?.();
+      return;
+    }
+
+    const scrollContainer = scrollContainerRef.current;
+    const shouldStickToBottom = scrollContainer ? isNearBottom(scrollContainer) : false;
+
+    setMessages((prev) => {
+      const ids = new Set(prev.map((item) => item.id));
+      const toAdd = incomingMessages.filter((m) => !ids.has(m.id));
+      if (toAdd.length === 0) return prev;
+
+      if (shouldStickToBottom) {
+        pendingScrollAdjustmentRef.current = { type: "append", behavior: "smooth" };
+      }
+
+      return [...prev, ...toAdd];
+    });
+    onIncomingMessagesProcessed?.();
+  }, [
+    incomingMessages,
+    isNearBottom,
+    messageViewMode,
+    newerCursor,
+    onIncomingMessagesProcessed,
+  ]);
+
+  const showContextLiveIndicator =
+    messageViewMode === "context" && contextLiveMessages.length > 0;
+
+  return {
+    messages,
+    loading,
+    error,
+    retryInitialLoad,
+    isLoadingMore,
+    isLoadingNewer,
+    nextCursor,
+    newMessagesAnchorId,
+    highlightedMessageId,
+    showJumpToLatest,
+    showContextLiveIndicator,
+    jumpToLatest,
+    scrollContainerRef,
+    sentinelRef,
+    bottomSentinelRef,
+    messagesEndRef,
+  };
+}

--- a/frontend/src/hooks/useMessageFeedViewport.ts
+++ b/frontend/src/hooks/useMessageFeedViewport.ts
@@ -1,0 +1,329 @@
+import { useCallback, useEffect, useLayoutEffect, useRef } from "react";
+import type { Dispatch, RefObject, SetStateAction } from "react";
+
+export type PendingScrollAdjustment =
+  | { type: "initial" }
+  | { type: "context-target"; targetMessageId: number }
+  | {
+      type: "prepend";
+      previousScrollTop: number;
+      previousScrollHeight: number;
+      anchorMessageId: number | null;
+      anchorTop: number | null;
+    }
+  | { type: "append"; behavior: ScrollBehavior };
+
+interface UseMessageFeedViewportParams {
+  density: "compact" | "comfortable";
+  messageViewMode: "normal" | "context";
+  messages: Array<{ id: string | number }>;
+  nextCursor: string | null;
+  newerCursor: string | null;
+  isLoadingMore: boolean;
+  isLoadingNewer: boolean;
+  isInitialPositioned: boolean;
+  setIsInitialPositioned: Dispatch<SetStateAction<boolean>>;
+  setShowJumpToLatest: Dispatch<SetStateAction<boolean>>;
+  scrollToLatestSignal: number;
+  onExitContextMode?: () => void;
+  loadOlderMessages: () => void;
+  loadNewerMessages: () => void;
+  scrollContainerRef: RefObject<HTMLDivElement | null>;
+  sentinelRef: RefObject<HTMLDivElement | null>;
+  bottomSentinelRef: RefObject<HTMLDivElement | null>;
+  messagesEndRef: RefObject<HTMLDivElement | null>;
+  pendingScrollAdjustmentRef: RefObject<PendingScrollAdjustment | null>;
+}
+
+interface UseMessageFeedViewportResult {
+  isNearBottom: (container: HTMLDivElement) => boolean;
+  jumpToLatest: () => void;
+}
+
+const JUMP_TO_LATEST_MIN_HIDDEN_MESSAGES = 50;
+const TOP_PREFETCH_ROOT_MARGIN = "900px";
+
+export function useMessageFeedViewport({
+  density,
+  messageViewMode,
+  messages,
+  nextCursor,
+  newerCursor,
+  isLoadingMore,
+  isLoadingNewer,
+  isInitialPositioned,
+  setIsInitialPositioned,
+  setShowJumpToLatest,
+  scrollToLatestSignal,
+  onExitContextMode,
+  loadOlderMessages,
+  loadNewerMessages,
+  scrollContainerRef,
+  sentinelRef,
+  bottomSentinelRef,
+  messagesEndRef,
+  pendingScrollAdjustmentRef,
+}: UseMessageFeedViewportParams): UseMessageFeedViewportResult {
+  const previousScrollToLatestSignalRef = useRef(scrollToLatestSignal);
+  const jumpVisibilitySuppressedRef = useRef(false);
+
+  const isNearBottom = useCallback((container: HTMLDivElement): boolean => {
+    const distanceFromBottom =
+      container.scrollHeight - container.scrollTop - container.clientHeight;
+    return distanceFromBottom < 100;
+  }, []);
+
+  const updateJumpToLatestVisibility = useCallback(() => {
+    const container = scrollContainerRef.current;
+
+    if (
+      !container ||
+      jumpVisibilitySuppressedRef.current ||
+      !isInitialPositioned
+    ) {
+      setShowJumpToLatest(false);
+      return;
+    }
+
+    if (messageViewMode === "context") {
+      if (newerCursor !== null) {
+        setShowJumpToLatest(true);
+        return;
+      }
+      if (isNearBottom(container)) {
+        setShowJumpToLatest(false);
+        return;
+      }
+      setShowJumpToLatest(true);
+      return;
+    }
+
+    if (isNearBottom(container)) {
+      setShowJumpToLatest(false);
+      return;
+    }
+
+    const viewportBottom = container.scrollTop + container.clientHeight;
+    const messageElements = container.querySelectorAll<HTMLElement>(
+      "[data-chat-message='true']",
+    );
+
+    let hiddenMessageCount = 0;
+    for (let i = messageElements.length - 1; i >= 0; i -= 1) {
+      const element = messageElements[i];
+      if (element.offsetTop < viewportBottom) {
+        break;
+      }
+      hiddenMessageCount += 1;
+    }
+
+    setShowJumpToLatest(
+      hiddenMessageCount >= JUMP_TO_LATEST_MIN_HIDDEN_MESSAGES,
+    );
+  }, [isInitialPositioned, isNearBottom, messageViewMode, newerCursor, scrollContainerRef, setShowJumpToLatest]);
+
+  useLayoutEffect(() => {
+    const container = scrollContainerRef.current;
+    const adjustment = pendingScrollAdjustmentRef.current;
+    if (!container || !adjustment) return;
+
+    if (adjustment.type === "initial") {
+      container.scrollTop = container.scrollHeight;
+      setIsInitialPositioned(true);
+    } else if (adjustment.type === "context-target") {
+      const targetElement = container.querySelector<HTMLElement>(
+        `[data-message-id='${adjustment.targetMessageId}']`,
+      );
+      if (targetElement) {
+        targetElement.scrollIntoView({ block: "center", behavior: "auto" });
+      } else {
+        container.scrollTop = container.scrollHeight;
+      }
+      setIsInitialPositioned(true);
+    } else if (adjustment.type === "prepend") {
+      if (
+        adjustment.anchorMessageId !== null &&
+        adjustment.anchorTop !== null
+      ) {
+        const anchorElement = container.querySelector<HTMLElement>(
+          `[data-message-id='${adjustment.anchorMessageId}']`,
+        );
+        if (anchorElement) {
+          const newAnchorTop = anchorElement.getBoundingClientRect().top;
+          // Keep the same message "pinned" in viewport after prepending variable-height rows.
+          container.scrollTop += newAnchorTop - adjustment.anchorTop;
+        } else {
+          const newScrollHeight = container.scrollHeight;
+          const heightDelta = newScrollHeight - adjustment.previousScrollHeight;
+          container.scrollTop = adjustment.previousScrollTop + heightDelta;
+        }
+      } else {
+        const newScrollHeight = container.scrollHeight;
+        const heightDelta = newScrollHeight - adjustment.previousScrollHeight;
+        container.scrollTop = adjustment.previousScrollTop + heightDelta;
+      }
+    } else {
+      messagesEndRef.current?.scrollIntoView({ behavior: adjustment.behavior });
+    }
+
+    pendingScrollAdjustmentRef.current = null;
+  }, [messages, messagesEndRef, pendingScrollAdjustmentRef, scrollContainerRef, setIsInitialPositioned]);
+
+  // Density changes alter message heights; pin to latest so on-screen context
+  // does not drift upward when switching between tight and comfy modes.
+  useLayoutEffect(() => {
+    if (!isInitialPositioned) return;
+    const container = scrollContainerRef.current;
+    if (!container) return;
+    container.scrollTop = container.scrollHeight;
+    setShowJumpToLatest(false);
+  }, [density, isInitialPositioned, scrollContainerRef, setShowJumpToLatest]);
+
+  // Sending a local message should always bring the user back to latest chat context.
+  useEffect(() => {
+    if (previousScrollToLatestSignalRef.current === scrollToLatestSignal) return;
+    previousScrollToLatestSignalRef.current = scrollToLatestSignal;
+    if (!isInitialPositioned) return;
+
+    if (messageViewMode === "context") {
+      onExitContextMode?.();
+      return;
+    }
+
+    const container = scrollContainerRef.current;
+    if (!container) return;
+
+    container.scrollTop = container.scrollHeight;
+    setShowJumpToLatest(false);
+  }, [
+    isInitialPositioned,
+    messageViewMode,
+    onExitContextMode,
+    scrollContainerRef,
+    scrollToLatestSignal,
+    setShowJumpToLatest,
+  ]);
+
+  useEffect(() => {
+    updateJumpToLatestVisibility();
+  }, [messages, updateJumpToLatestVisibility, messageViewMode]);
+
+  useEffect(() => {
+    const container = scrollContainerRef.current;
+    if (!container || !isInitialPositioned) return;
+
+    const handleScroll = () => {
+      if (jumpVisibilitySuppressedRef.current) {
+        if (isNearBottom(container)) {
+          jumpVisibilitySuppressedRef.current = false;
+        } else {
+          setShowJumpToLatest(false);
+          return;
+        }
+      }
+      updateJumpToLatestVisibility();
+    };
+
+    container.addEventListener("scroll", handleScroll, { passive: true });
+    handleScroll();
+
+    return () => {
+      container.removeEventListener("scroll", handleScroll);
+    };
+  }, [
+    isInitialPositioned,
+    isNearBottom,
+    scrollContainerRef,
+    setShowJumpToLatest,
+    updateJumpToLatestVisibility,
+  ]);
+
+  const jumpToLatest = useCallback(() => {
+    if (messageViewMode === "context") {
+      onExitContextMode?.();
+      return;
+    }
+
+    const container = scrollContainerRef.current;
+    if (!container) return;
+
+    // Keep jump affordance hidden until animated programmatic scroll actually
+    // reaches latest, so long-distance jumps do not flash the button mid-flight.
+    jumpVisibilitySuppressedRef.current = true;
+    container.scrollTo({ top: container.scrollHeight, behavior: "smooth" });
+    setShowJumpToLatest(false);
+  }, [messageViewMode, onExitContextMode, scrollContainerRef, setShowJumpToLatest]);
+
+  useEffect(() => {
+    if (!isInitialPositioned) return;
+
+    const sentinel = sentinelRef.current;
+    if (!sentinel) return;
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (entries[0].isIntersecting && nextCursor && !isLoadingMore) {
+          loadOlderMessages();
+        }
+      },
+      {
+        root: scrollContainerRef.current,
+        // Start loading older history well before hard-top so users keep scrolling smoothly.
+        rootMargin: TOP_PREFETCH_ROOT_MARGIN,
+        threshold: 0,
+      }
+    );
+
+    observer.observe(sentinel);
+
+    return () => {
+      observer.disconnect();
+    };
+  }, [
+    isInitialPositioned,
+    isLoadingMore,
+    loadOlderMessages,
+    nextCursor,
+    scrollContainerRef,
+    sentinelRef,
+  ]);
+
+  useEffect(() => {
+    if (!isInitialPositioned || messageViewMode !== "context") return;
+
+    const sentinel = bottomSentinelRef.current;
+    if (!sentinel) return;
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (entries[0].isIntersecting && newerCursor && !isLoadingNewer) {
+          loadNewerMessages();
+        }
+      },
+      {
+        root: scrollContainerRef.current,
+        rootMargin: "100px",
+        threshold: 0,
+      }
+    );
+
+    observer.observe(sentinel);
+
+    return () => {
+      observer.disconnect();
+    };
+  }, [
+    bottomSentinelRef,
+    isInitialPositioned,
+    isLoadingNewer,
+    loadNewerMessages,
+    messageViewMode,
+    newerCursor,
+    scrollContainerRef,
+  ]);
+
+  return {
+    isNearBottom,
+    jumpToLatest,
+  };
+}

--- a/plans/task-frontend-component-refactor-02-message-list.md
+++ b/plans/task-frontend-component-refactor-02-message-list.md
@@ -50,3 +50,117 @@ cd frontend && npm test
 - [ ] PR references this issue (`Closes #...`).
 - [ ] Docs updated if needed (`docs/ARCHITECTURE.md`, `docs/PATTERNS.md`, `docs/REVIEW_CHECKLIST.md`, `backend/TESTPLAN.md`, `docs/adr/`).
 - [ ] Tests added/updated where needed.
+
+## Detailed Refactor Whiteboard (Pre-Implementation)
+
+### Current Responsibility Map (`MessageList.tsx`)
+- Feed lifecycle orchestration:
+  - normal-mode initial history fetch with timeout and retry
+  - context-mode payload hydration (target highlight + cursors)
+  - older/newer pagination requests with stale-response protection
+  - incoming live append logic for both normal and context modes
+  - context live-buffer carryover when exiting context mode
+- Scroll orchestration:
+  - initial positioning and context-target centering
+  - prepend anchor capture + scroll restoration
+  - append-to-bottom behavior when near latest
+  - jump-to-latest visibility rules and suppression during animated jumps
+  - top/bottom IntersectionObserver wiring for pagination
+- Presentation and formatting:
+  - date divider + NEW MESSAGES divider resolution
+  - grouped message rendering and avatar/hover timestamp variants
+  - loading/error/empty markers and pagination indicators
+  - jump button rendering and labels in normal vs context mode
+- Utility logic embedded in component:
+  - timestamp normalization/parsing
+  - strict recency comparison across mixed timestamp formats
+  - unread anchor selection from initial room-entry snapshot
+
+### Refactor Goals for This Task
+- Keep `MessageList` public props, behavior, and room/chat integration semantics unchanged.
+- Move feed lifecycle + pagination + scroll-correction state orchestration into a dedicated hook.
+- Move row/divider rendering into focused presentational components under a feature-scoped directory.
+- Keep message formatting rules and context-mode behavior identical to current implementation.
+
+### Planned File Changes
+- `frontend/src/components/MessageList.tsx` (convert to composition container; keep external contract stable)
+- `frontend/src/hooks/useMessageFeedLifecycle.ts` (new; fetch/pagination/live-append/scroll orchestration)
+- `frontend/src/components/message-list/MessageFeedContent.tsx` (new; list markers + row composition)
+- `frontend/src/components/message-list/MessageRow.tsx` (new; grouped/non-grouped row rendering)
+- `frontend/src/components/message-list/messageListFormatting.ts` (new; timestamp/date/grouping helpers reused by container + feed rendering)
+- `frontend/src/components/__tests__/MessageList.test.tsx` (update/add targeted regression tests)
+
+### Hook Contract Draft (`useMessageFeedLifecycle`)
+- Inputs:
+  - `roomId`
+  - `token`
+  - `userId`
+  - `density`
+  - `messageViewMode`
+  - `messageContext`
+  - `lastReadAtSnapshot`
+  - `incomingMessages`
+  - `scrollToLatestSignal`
+  - `onIncomingMessagesProcessed`
+  - `onExitContextMode`
+- State returned:
+  - `messages`, `loading`, `error`
+  - `nextCursor`, `newerCursor`
+  - `isLoadingMore`, `isLoadingNewer`
+  - `showJumpToLatest`
+  - `showContextLiveIndicator`
+  - `highlightedMessageId`
+  - `newMessagesAnchorId`
+  - `isInitialPositioned`
+- Refs returned:
+  - `scrollContainerRef`, `sentinelRef`, `bottomSentinelRef`, `messagesEndRef`
+- Actions returned:
+  - `retryInitialLoad`
+  - `jumpToLatest`
+- Non-functional requirements:
+  - preserve timeout message text, stale-epoch guards, divider anchor stability, and no-drop incoming append behavior.
+
+### Component Contract Drafts
+- `MessageFeedContent`:
+  - receives list state (`messages`, `newMessagesAnchorId`, `highlightedMessageId`, `density`, `theme`)
+  - receives formatting helpers and renders date/new-message dividers + row list
+  - remains render-only (no async side effects)
+- `MessageRow`:
+  - receives one message item + grouping/highlight metadata
+  - preserves avatar vs hover-time behavior and all existing typography/styling decisions
+  - keeps `data-chat-message` and `data-message-id` attributes unchanged for scroll logic/tests
+
+### Execution Steps (with verification checkpoints)
+1. Extract pure formatting/grouping helpers into `messageListFormatting.ts` and wire existing component to them.
+   - Verify: targeted `MessageList` tests for date/group/divider behavior still pass.
+2. Extract lifecycle/pagination/scroll orchestration into `useMessageFeedLifecycle` while keeping current JSX in place.
+   - Verify: targeted tests for append, context transitions, stale responses, and jump behavior pass.
+3. Extract render tree into `MessageFeedContent` + `MessageRow` and keep `MessageList` as container.
+   - Verify: tests for divider placement, highlight rendering, and jump CTA behavior pass.
+4. Remove orphan logic/imports, run full frontend verification, then run full frontend test suite.
+   - Verify: `npx tsc --noEmit`, `npx eslint src/`, `npm run build`, `npm test -- MessageList.test.tsx`, `npm test`.
+
+### Regression Guardrails (must stay true)
+- Normal-mode initial load remains newest API page reversed to chronological UI order.
+- Context-mode target centering/highlight behavior remains unchanged.
+- Older-page prepend keeps viewport anchor stable with variable row heights.
+- Incoming WS messages are not dropped under rapid bursts in either view mode.
+- NEW MESSAGES divider anchor is resolved once per room-entry snapshot and does not shift mid-session.
+- Jump-to-latest visibility thresholds/suppression behavior remain unchanged.
+- `data-chat-message` and `data-message-id` attributes remain present for scroll and test selectors.
+
+### Cross-Task Compatibility Checklist (`#16` -> `#17/#18`)
+- [ ] `MessageListProps` public contract is unchanged (no prop rename/removal/semantic shift).
+- [ ] `onIncomingMessagesProcessed` invocation semantics remain unchanged (called once per processed incoming batch).
+- [ ] `scrollToLatestSignal` edge-trigger semantics remain unchanged.
+- [ ] `onExitContextMode` ownership remains unchanged (triggered only through context jump flows/signals as before).
+- [ ] Context-to-normal transition keeps buffered live messages with strict recency filtering.
+- [ ] Normal vs context cursor semantics (`nextCursor`/`newerCursor`) remain unchanged.
+- [ ] No `MessageArea` or `ChatLayout` orchestration contract changes are introduced.
+- [ ] No API service signatures (`getRoomMessages`, `getRoomMessagesNewer`) are changed.
+
+### Test Additions Planned
+- Add regression test that a batched incoming set in context mode preserves dedupe + processed callback behavior.
+- Add regression test that extracted row component preserves `data-message-id` attributes for anchor restoration.
+- Add regression test that jump-to-latest action label switches correctly between hidden backlog and context live-indicator cases.
+- Keep existing stale-response and context-exit carryover tests intact while adjusting for extracted component boundaries.


### PR DESCRIPTION
## Summary
- decompose MessageList into a thin container plus focused hooks/components
- extract feed lifecycle orchestration to useMessageFeedLifecycle
- extract viewport/scroll/jump behavior to useMessageFeedViewport
- extract message rendering and formatting helpers under components/message-list
- add targeted MessageList regressions for data attributes and context incoming dedupe

## Verification
- cd frontend && npx tsc --noEmit
- cd frontend && npx eslint src/
- cd frontend && npm run build
- cd frontend && npm test -- MessageList.test.tsx
- cd frontend && npm test

Closes #16