### PR TITLE
refactor: decompose ChatLayout orchestration

### DIFF
--- a/frontend/src/components/ChatLayout.tsx
+++ b/frontend/src/components/ChatLayout.tsx
@@ -4,10 +4,15 @@ import MessageArea from "./MessageArea";
 import UsersPanel from "./UsersPanel";
 import SearchPanel from "./SearchPanel";
 import { useWebSocketContext } from "../context/useWebSocketContext";
-import { type WebSocketMessage } from "../context/WebSocketContext";
 import { useAuth } from "../context/AuthContext";
 import { markRoomRead, leaveRoom } from "../services/api";
 import { formatRoomNameForDisplay } from "../utils/roomNames";
+import { useChatLayoutMessageHandler } from "../hooks/useChatLayoutMessageHandler";
+import { useChatLayoutSubscriptions } from "../hooks/useChatLayoutSubscriptions";
+import {
+  clearRoomScopedState,
+  resetSelectedRoomState,
+} from "./chat-layout/chatLayoutRoomState";
 import type { Message, MessageContextResponse, OnlineUser, Room } from "../types";
 
 const MAX_SUBSCRIPTIONS = 10;
@@ -175,123 +180,48 @@ export default function ChatLayout() {
     return () => window.removeEventListener("keydown", handleGlobalShortcuts);
   }, [selectedRoom]);
 
-  useEffect(() => {
-    const handleMessage = (msg: WebSocketMessage) => {
-      // Show WS errors (e.g. rate limit) as an ephemeral banner that auto-clears
-      if (msg.type === "error") {
-        setWsError(msg.message);
-        setTimeout(() => setWsError(null), 4000);
-        return;
-      }
-
-      const msgRoomId =
-        msg.type === "new_message"
-          ? msg.message.room_id
-          : "room_id" in msg
-            ? msg.room_id
-            : null;
-
-      if (msg.type === "new_message" && msgRoomId != null) {
-        if (msgRoomId === selectedRoomRef.current?.id) {
-          setIncomingMessagesForRoom((prev) => [...prev, msg.message]);
-          const t = tokenRef.current;
-          if (t) {
-            markRoomRead(msgRoomId, t)
-              .then((response) => {
-                setLastReadAtByRoomId((prev) => ({
-                  ...prev,
-                  [msgRoomId]: response.last_read_at,
-                }));
-              })
-              .catch(() => {});
-          }
-        } else if (subscribedRoomIdsRef.current.includes(msgRoomId)) {
-          setUnreadCounts((prev) => ({
-            ...prev,
-            [msgRoomId]: (prev[msgRoomId] ?? 0) + 1,
-          }));
-        }
-
-        // Clear typing indicator for the sender (they finished composing)
-        setTypingUsersByRoom((prev) => {
-          const roomTyping = prev[msgRoomId];
-          if (!roomTyping || !roomTyping[msg.message.user_id]) return prev;
-          clearTimeout(roomTyping[msg.message.user_id].timeout);
-          typingTimeoutsRef.current.delete(roomTyping[msg.message.user_id].timeout);
-          const updated = { ...roomTyping };
-          delete updated[msg.message.user_id];
-          return { ...prev, [msgRoomId]: updated };
-        });
-
-        return;
-      }
-
-      if (msgRoomId == null) return;
-
-      switch (msg.type) {
-        case "subscribed":
-          setOnlineUsersByRoom((prev) => ({
-            ...prev,
-            [msgRoomId]: msg.online_users,
-          }));
-          break;
-        case "user_joined":
-          setOnlineUsersByRoom((prev) => {
-            const list = prev[msgRoomId] ?? [];
-            const exists = list.some((u) => u.id === msg.user.id);
-            return {
-              ...prev,
-              [msgRoomId]: exists ? list : [...list, msg.user],
-            };
-          });
-          break;
-        case "user_left":
-          setOnlineUsersByRoom((prev) => ({
-            ...prev,
-            [msgRoomId]: (prev[msgRoomId] ?? []).filter((u) => u.id !== msg.user.id),
-          }));
-          break;
-        case "typing_indicator":
-          {
-            const { room_id, user } = msg;
-
-            setTypingUsersByRoom((prev) => {
-              // Clone the relevant room's typing map (or start fresh)
-              const roomTyping = { ...(prev[room_id] ?? {}) };
-
-              // Clear existing timeout for this user (they're still typing)
-              if (roomTyping[user.id]) {
-                clearTimeout(roomTyping[user.id].timeout);
-                typingTimeoutsRef.current.delete(roomTyping[user.id].timeout);
-              }
-
-              // Set a 3s auto-clear timeout
-              const timeout = setTimeout(() => {
-                setTypingUsersByRoom((current) => {
-                  const updated = { ...(current[room_id] ?? {}) };
-                  delete updated[user.id];
-                  return { ...current, [room_id]: updated };
-                });
-                typingTimeoutsRef.current.delete(timeout);
-              }, 3000);
-
-              // Track timeout for cleanup
-              typingTimeoutsRef.current.add(timeout);
-
-              roomTyping[user.id] = { username: user.username, timeout };
-              return { ...prev, [room_id]: roomTyping };
-            });
-          }
-          break;
-      }
-    };
-    registerMessageHandler(handleMessage);
-    return () => registerMessageHandler(undefined);
-  }, [registerMessageHandler]);
+  useChatLayoutMessageHandler({
+    registerMessageHandler,
+    selectedRoomRef,
+    subscribedRoomIdsRef,
+    tokenRef,
+    typingTimeoutsRef,
+    setIncomingMessagesForRoom,
+    setUnreadCounts,
+    setLastReadAtByRoomId,
+    setOnlineUsersByRoom,
+    setTypingUsersByRoom,
+    setWsError,
+  });
 
   // ============================================================================
   // HANDLERS
   // ============================================================================
+
+  const resetSelectionState = () => {
+    resetSelectedRoomState({
+      setSelectedRoom,
+      setMessageViewMode,
+      setMessageContext,
+      setRoomOpenLastReadSnapshot,
+      setIncomingMessagesForRoom,
+    });
+  };
+
+  const cleanupRoomState = (roomId: number) => {
+    clearRoomScopedState({
+      roomId,
+      setOnlineUsersByRoom,
+      setLastReadAtByRoomId,
+      setUnreadCounts,
+      setTypingUsersByRoom,
+    });
+  };
+
+  const unsubscribeRoom = (roomId: number) => {
+    unsubscribe(roomId);
+    setSubscribedRoomIds((prev) => prev.filter((id) => id !== roomId));
+  };
 
   const handleSelectRoom = async (room: Room) => {
     setLeaveError(null);
@@ -340,38 +270,15 @@ export default function ChatLayout() {
   const handleRoomDeleted = () => {
     const deletedRoomId = selectedRoom?.id;
     if (deletedRoomId == null) return;
-    setSubscribedRoomIds((prev) => prev.filter((id) => id !== deletedRoomId));
-    unsubscribe(deletedRoomId);
-    setSelectedRoom(null);
-    setMessageViewMode("normal");
-    setMessageContext(null);
-    setRoomOpenLastReadSnapshot(null);
-    setIncomingMessagesForRoom([]);
-    setOnlineUsersByRoom((prev) => {
-      const next = { ...prev };
-      delete next[deletedRoomId];
-      return next;
-    });
-    setLastReadAtByRoomId((prev) => {
-      const next = { ...prev };
-      delete next[deletedRoomId];
-      return next;
-    });
-    setUnreadCounts((prev) => {
-      const next = { ...prev };
-      delete next[deletedRoomId];
-      return next;
-    });
+    unsubscribeRoom(deletedRoomId);
+    resetSelectionState();
+    cleanupRoomState(deletedRoomId);
     setRefreshTrigger((prev) => prev + 1);
   };
 
   const handleLeaveRoom = async () => {
     if (!selectedRoom || !token) {
-      setSelectedRoom(null);
-      setMessageViewMode("normal");
-      setMessageContext(null);
-      setRoomOpenLastReadSnapshot(null);
-      setIncomingMessagesForRoom([]);
+      resetSelectionState();
       return;
     }
 
@@ -391,29 +298,9 @@ export default function ChatLayout() {
       // Still clear selection and unsubscribe so the user isn't stuck
     }
 
-    // Unsubscribe from WebSocket and remove from local subscription list
-    unsubscribe(roomId);
-  setSubscribedRoomIds((prev) => prev.filter((id) => id !== roomId));
-  setSelectedRoom(null);
-  setMessageViewMode("normal");
-  setMessageContext(null);
-  setRoomOpenLastReadSnapshot(null);
-    setIncomingMessagesForRoom([]);
-    setOnlineUsersByRoom((prev) => {
-      const next = { ...prev };
-      delete next[roomId];
-      return next;
-    });
-    setLastReadAtByRoomId((prev) => {
-      const next = { ...prev };
-      delete next[roomId];
-      return next;
-    });
-    setUnreadCounts((prev) => {
-      const next = { ...prev };
-      delete next[roomId];
-      return next;
-    });
+    unsubscribeRoom(roomId);
+    resetSelectionState();
+    cleanupRoomState(roomId);
     // Refresh room list so the left room disappears from the sidebar
     setRefreshTrigger((prev) => prev + 1);
   };
@@ -462,46 +349,15 @@ export default function ChatLayout() {
   // EFFECTS
   // ============================================================================
 
-  // Subscribe only to rooms we haven't sent subscribe for yet (avoids duplicate subscribe on re-run or when list grows)
-  useEffect(() => {
-    let refreshTimeoutId: number | undefined;
-
-    // Server subscription state is reset on reconnect; clear local sent-cache so rooms are re-subscribed.
-    if (!prevConnectedRef.current && connected) {
-      subscribedSentRef.current.clear();
-      // Pull fresh unread counts after reconnect because messages may have arrived while disconnected.
-      if (hasConnectedOnceRef.current) {
-        refreshTimeoutId = window.setTimeout(() => {
-          setRefreshTrigger((prev) => prev + 1);
-        }, 0);
-      }
-      hasConnectedOnceRef.current = true;
-    }
-    prevConnectedRef.current = connected;
-
-    return () => {
-      if (refreshTimeoutId) {
-        clearTimeout(refreshTimeoutId);
-      }
-    };
-  }, [connected]);
-
-  useEffect(() => {
-    if (!connected || subscribedRoomIds.length === 0) return;
-
-    subscribedRoomIds.forEach((id) => {
-      if (!subscribedSentRef.current.has(id)) {
-        subscribe(id);
-        subscribedSentRef.current.add(id);
-      }
-    });
-
-    // Drop ref entries for rooms no longer in the list (unsubscribed elsewhere)
-    const idSet = new Set(subscribedRoomIds);
-    subscribedSentRef.current.forEach((id) => {
-      if (!idSet.has(id)) subscribedSentRef.current.delete(id);
-    });
-  }, [connected, subscribedRoomIds, subscribe]);
+  useChatLayoutSubscriptions({
+    connected,
+    subscribedRoomIds,
+    subscribe,
+    setRefreshTrigger,
+    subscribedSentRef,
+    prevConnectedRef,
+    hasConnectedOnceRef,
+  });
 
   // Clean up all typing timeouts on unmount
   useEffect(() => {

--- a/frontend/src/components/__tests__/ChatLayout.test.tsx
+++ b/frontend/src/components/__tests__/ChatLayout.test.tsx
@@ -1,0 +1,283 @@
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { WebSocketMessage } from "../../context/WebSocketContext";
+import type { Room } from "../../types";
+import ChatLayout from "../ChatLayout";
+
+const mockSubscribe = vi.fn();
+const mockUnsubscribe = vi.fn();
+const mockMarkRoomRead = vi.fn();
+const mockLeaveRoom = vi.fn();
+const mockLogout = vi.fn();
+
+const roomOne: Room = {
+  id: 1,
+  name: "General Discussion",
+  created_by: 1,
+  created_at: "2024-01-01T00:00:00",
+  last_read_at: "2024-01-01T00:00:00",
+};
+
+const roomTwo: Room = {
+  id: 2,
+  name: "Backend Room",
+  created_by: 2,
+  created_at: "2024-01-01T00:00:00",
+  last_read_at: "2024-01-01T00:00:00",
+};
+
+type SidebarMockProps = {
+  onSelectRoom: (room: Room) => void;
+  refreshTrigger: number;
+  unreadCounts: Record<number, number>;
+};
+
+type MessageAreaMockProps = {
+  selectedRoom: Room | null;
+  incomingMessages: Array<{ id: number }>;
+  wsError?: string | null;
+  onLeaveRoom: () => void;
+  onRoomDeleted: () => void;
+};
+
+type UsersPanelMockProps = {
+  onlineUsers: Array<{ id: number; username: string }>;
+};
+
+let latestSidebarProps: SidebarMockProps | null = null;
+let latestUsersPanelProps: UsersPanelMockProps | null = null;
+let wsMessageHandler: ((message: WebSocketMessage) => void) | undefined;
+
+vi.mock("../../context/AuthContext", () => ({
+  useAuth: () => ({
+    user: {
+      id: 1,
+      username: "alice",
+      email: "alice@example.com",
+      created_at: "2024-01-01T00:00:00",
+    },
+    token: "test-token",
+    logout: (...args: unknown[]) => mockLogout(...args),
+  }),
+}));
+
+vi.mock("../../context/useWebSocketContext", () => ({
+  useWebSocketContext: () => ({
+    connected: true,
+    subscribe: (...args: unknown[]) => mockSubscribe(...args),
+    unsubscribe: (...args: unknown[]) => mockUnsubscribe(...args),
+    registerMessageHandler: (
+      handler: ((message: WebSocketMessage) => void) | undefined,
+    ) => {
+      wsMessageHandler = handler;
+    },
+  }),
+}));
+
+vi.mock("../../services/api", () => ({
+  markRoomRead: (...args: unknown[]) => mockMarkRoomRead(...args),
+  leaveRoom: (...args: unknown[]) => mockLeaveRoom(...args),
+}));
+
+vi.mock("../Sidebar", () => ({
+  default: (props: SidebarMockProps) => {
+    latestSidebarProps = props;
+    return (
+      <div>
+        <div data-testid="refresh-trigger">{props.refreshTrigger}</div>
+        <button type="button" onClick={() => props.onSelectRoom(roomOne)}>
+          Select Room One
+        </button>
+        <button type="button" onClick={() => props.onSelectRoom(roomTwo)}>
+          Select Room Two
+        </button>
+      </div>
+    );
+  },
+}));
+
+vi.mock("../MessageArea", () => ({
+  default: ({
+    selectedRoom,
+    incomingMessages,
+    wsError,
+    onLeaveRoom,
+    onRoomDeleted,
+  }: MessageAreaMockProps) => (
+    <div>
+      <div data-testid="selected-room-id">{selectedRoom?.id ?? "none"}</div>
+      <div data-testid="incoming-count">{incomingMessages.length}</div>
+      <div data-testid="ws-error-text">{wsError ?? ""}</div>
+      <button type="button" onClick={onLeaveRoom}>
+        Leave Room
+      </button>
+      <button type="button" onClick={onRoomDeleted}>
+        Delete Room
+      </button>
+    </div>
+  ),
+}));
+
+vi.mock("../UsersPanel", () => ({
+  default: (props: UsersPanelMockProps) => {
+    latestUsersPanelProps = props;
+    return <div data-testid="online-count">{props.onlineUsers.length}</div>;
+  },
+}));
+
+vi.mock("../SearchPanel", () => ({
+  default: () => null,
+}));
+
+function emitWsMessage(message: WebSocketMessage) {
+  if (!wsMessageHandler) {
+    throw new Error("WS handler is not registered");
+  }
+  act(() => {
+    wsMessageHandler?.(message);
+  });
+}
+
+describe("ChatLayout", () => {
+  beforeEach(() => {
+    mockSubscribe.mockReset();
+    mockUnsubscribe.mockReset();
+    mockMarkRoomRead.mockReset();
+    mockLeaveRoom.mockReset();
+    mockLogout.mockReset();
+    latestSidebarProps = null;
+    latestUsersPanelProps = null;
+    wsMessageHandler = undefined;
+    mockMarkRoomRead.mockResolvedValue({ last_read_at: "2024-01-02T00:00:00" });
+    mockLeaveRoom.mockResolvedValue({ room_id: 1 });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("subscribes when selecting a room and keeps selected room state", async () => {
+    render(<ChatLayout />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Select Room One" }));
+
+    await waitFor(() => {
+      expect(mockSubscribe).toHaveBeenCalledWith(1);
+    });
+    expect(screen.getByTestId("selected-room-id")).toHaveTextContent("1");
+  });
+
+  it("leave flow clears selection, unsubscribes, and refreshes even when API leave fails", async () => {
+    mockLeaveRoom.mockRejectedValueOnce(new Error("Room creator cannot leave"));
+    render(<ChatLayout />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Select Room One" }));
+    await waitFor(() => {
+      expect(screen.getByTestId("selected-room-id")).toHaveTextContent("1");
+    });
+    await waitFor(() => {
+      expect(mockMarkRoomRead).toHaveBeenCalledTimes(1);
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Leave Room" }));
+
+    await waitFor(() => {
+      expect(mockLeaveRoom).toHaveBeenCalledWith(1, "test-token");
+    });
+    expect(mockUnsubscribe).toHaveBeenCalledWith(1);
+    expect(screen.getByTestId("selected-room-id")).toHaveTextContent("none");
+    expect(screen.getByTestId("refresh-trigger")).toHaveTextContent("1");
+    expect(screen.getByText("Room creator cannot leave")).toBeInTheDocument();
+  });
+
+  it("delete flow prunes room-scoped online users so reselecting starts clean", async () => {
+    render(<ChatLayout />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Select Room One" }));
+    await waitFor(() => {
+      expect(screen.getByTestId("selected-room-id")).toHaveTextContent("1");
+    });
+
+    emitWsMessage({
+      type: "subscribed",
+      room_id: 1,
+      online_users: [{ id: 22, username: "bob" }],
+    });
+    expect(screen.getByTestId("online-count")).toHaveTextContent("1");
+    expect(latestUsersPanelProps?.onlineUsers[0]?.username).toBe("bob");
+
+    fireEvent.click(screen.getByRole("button", { name: "Delete Room" }));
+    expect(mockUnsubscribe).toHaveBeenCalledWith(1);
+    expect(screen.getByTestId("selected-room-id")).toHaveTextContent("none");
+    expect(screen.getByTestId("refresh-trigger")).toHaveTextContent("1");
+
+    fireEvent.click(screen.getByRole("button", { name: "Select Room One" }));
+    await waitFor(() => {
+      expect(screen.getByTestId("selected-room-id")).toHaveTextContent("1");
+    });
+    await waitFor(() => {
+      expect(mockMarkRoomRead).toHaveBeenCalledTimes(2);
+    });
+    expect(screen.getByTestId("online-count")).toHaveTextContent("0");
+  });
+
+  it("routes websocket new_message to incoming queue or unread counts based on selected room", async () => {
+    render(<ChatLayout />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Select Room One" }));
+    await waitFor(() => {
+      expect(screen.getByTestId("selected-room-id")).toHaveTextContent("1");
+    });
+
+    emitWsMessage({
+      type: "new_message",
+      message: {
+        id: 101,
+        room_id: 1,
+        user_id: 9,
+        username: "bob",
+        content: "hello",
+        created_at: "2024-01-01T00:00:00",
+      },
+    });
+    expect(screen.getByTestId("incoming-count")).toHaveTextContent("1");
+
+    fireEvent.click(screen.getByRole("button", { name: "Select Room Two" }));
+    await waitFor(() => {
+      expect(screen.getByTestId("selected-room-id")).toHaveTextContent("2");
+    });
+
+    emitWsMessage({
+      type: "new_message",
+      message: {
+        id: 102,
+        room_id: 1,
+        user_id: 9,
+        username: "bob",
+        content: "still there",
+        created_at: "2024-01-01T00:00:10",
+      },
+    });
+
+    expect(latestSidebarProps?.unreadCounts[1]).toBe(1);
+  });
+
+  it("shows websocket errors and auto-clears the banner after four seconds", async () => {
+    vi.useFakeTimers();
+    render(<ChatLayout />);
+
+    emitWsMessage({
+      type: "error",
+      message: "Message rate limit exceeded",
+    });
+    expect(screen.getByTestId("ws-error-text")).toHaveTextContent(
+      "Message rate limit exceeded",
+    );
+
+    act(() => {
+      vi.advanceTimersByTime(4000);
+    });
+
+    expect(screen.getByTestId("ws-error-text")).toHaveTextContent("");
+  });
+});

--- a/frontend/src/components/chat-layout/chatLayoutRoomState.ts
+++ b/frontend/src/components/chat-layout/chatLayoutRoomState.ts
@@ -1,0 +1,61 @@
+import type { Dispatch, SetStateAction } from "react";
+import type { Message, MessageContextResponse, OnlineUser, Room } from "../../types";
+
+type MessageViewMode = "normal" | "context";
+type TypingUsersByRoom = Record<
+  number,
+  Record<number, { username: string; timeout: ReturnType<typeof setTimeout> }>
+>;
+
+interface ResetSelectedRoomStateParams {
+  setSelectedRoom: Dispatch<SetStateAction<Room | null>>;
+  setMessageViewMode: Dispatch<SetStateAction<MessageViewMode>>;
+  setMessageContext: Dispatch<SetStateAction<MessageContextResponse | null>>;
+  setRoomOpenLastReadSnapshot: Dispatch<SetStateAction<string | null>>;
+  setIncomingMessagesForRoom: Dispatch<SetStateAction<Message[]>>;
+}
+
+interface ClearRoomScopedStateParams {
+  roomId: number;
+  setOnlineUsersByRoom: Dispatch<SetStateAction<Record<number, OnlineUser[]>>>;
+  setLastReadAtByRoomId: Dispatch<SetStateAction<Record<number, string | null>>>;
+  setUnreadCounts: Dispatch<SetStateAction<Record<number, number>>>;
+  setTypingUsersByRoom: Dispatch<SetStateAction<TypingUsersByRoom>>;
+}
+
+function omitRoomKey<T>(prev: Record<number, T>, roomId: number): Record<number, T> {
+  if (!Object.prototype.hasOwnProperty.call(prev, roomId)) {
+    return prev;
+  }
+
+  const next = { ...prev };
+  delete next[roomId];
+  return next;
+}
+
+export function resetSelectedRoomState({
+  setSelectedRoom,
+  setMessageViewMode,
+  setMessageContext,
+  setRoomOpenLastReadSnapshot,
+  setIncomingMessagesForRoom,
+}: ResetSelectedRoomStateParams): void {
+  setSelectedRoom(null);
+  setMessageViewMode("normal");
+  setMessageContext(null);
+  setRoomOpenLastReadSnapshot(null);
+  setIncomingMessagesForRoom([]);
+}
+
+export function clearRoomScopedState({
+  roomId,
+  setOnlineUsersByRoom,
+  setLastReadAtByRoomId,
+  setUnreadCounts,
+  setTypingUsersByRoom,
+}: ClearRoomScopedStateParams): void {
+  setOnlineUsersByRoom((prev) => omitRoomKey(prev, roomId));
+  setLastReadAtByRoomId((prev) => omitRoomKey(prev, roomId));
+  setUnreadCounts((prev) => omitRoomKey(prev, roomId));
+  setTypingUsersByRoom((prev) => omitRoomKey(prev, roomId));
+}

--- a/frontend/src/hooks/useChatLayoutMessageHandler.ts
+++ b/frontend/src/hooks/useChatLayoutMessageHandler.ts
@@ -1,0 +1,169 @@
+import {
+  useEffect,
+  type Dispatch,
+  type MutableRefObject,
+  type SetStateAction,
+} from "react";
+import type { WebSocketMessage } from "../context/WebSocketContext";
+import { markRoomRead } from "../services/api";
+import type { Message, OnlineUser, Room } from "../types";
+
+type TypingUsersByRoom = Record<
+  number,
+  Record<number, { username: string; timeout: ReturnType<typeof setTimeout> }>
+>;
+
+interface UseChatLayoutMessageHandlerParams {
+  registerMessageHandler: (handler: ((msg: WebSocketMessage) => void) | undefined) => void;
+  selectedRoomRef: MutableRefObject<Room | null>;
+  subscribedRoomIdsRef: MutableRefObject<number[]>;
+  tokenRef: MutableRefObject<string | null>;
+  typingTimeoutsRef: MutableRefObject<Set<ReturnType<typeof setTimeout>>>;
+  setIncomingMessagesForRoom: Dispatch<SetStateAction<Message[]>>;
+  setUnreadCounts: Dispatch<SetStateAction<Record<number, number>>>;
+  setLastReadAtByRoomId: Dispatch<SetStateAction<Record<number, string | null>>>;
+  setOnlineUsersByRoom: Dispatch<SetStateAction<Record<number, OnlineUser[]>>>;
+  setTypingUsersByRoom: Dispatch<SetStateAction<TypingUsersByRoom>>;
+  setWsError: Dispatch<SetStateAction<string | null>>;
+}
+
+export function useChatLayoutMessageHandler({
+  registerMessageHandler,
+  selectedRoomRef,
+  subscribedRoomIdsRef,
+  tokenRef,
+  typingTimeoutsRef,
+  setIncomingMessagesForRoom,
+  setUnreadCounts,
+  setLastReadAtByRoomId,
+  setOnlineUsersByRoom,
+  setTypingUsersByRoom,
+  setWsError,
+}: UseChatLayoutMessageHandlerParams): void {
+  useEffect(() => {
+    const handleMessage = (message: WebSocketMessage) => {
+      if (message.type === "error") {
+        setWsError(message.message);
+        setTimeout(() => setWsError(null), 4000);
+        return;
+      }
+
+      const messageRoomId =
+        message.type === "new_message"
+          ? message.message.room_id
+          : "room_id" in message
+            ? message.room_id
+            : null;
+
+      if (message.type === "new_message" && messageRoomId != null) {
+        if (messageRoomId === selectedRoomRef.current?.id) {
+          setIncomingMessagesForRoom((prev) => [...prev, message.message]);
+          const token = tokenRef.current;
+          if (token) {
+            markRoomRead(messageRoomId, token)
+              .then((response) => {
+                setLastReadAtByRoomId((prev) => ({
+                  ...prev,
+                  [messageRoomId]: response.last_read_at,
+                }));
+              })
+              .catch(() => {});
+          }
+        } else if (subscribedRoomIdsRef.current.includes(messageRoomId)) {
+          setUnreadCounts((prev) => ({
+            ...prev,
+            [messageRoomId]: (prev[messageRoomId] ?? 0) + 1,
+          }));
+        }
+
+        // Sender finished typing once their message is published.
+        setTypingUsersByRoom((prev) => {
+          const roomTyping = prev[messageRoomId];
+          if (!roomTyping || !roomTyping[message.message.user_id]) {
+            return prev;
+          }
+          clearTimeout(roomTyping[message.message.user_id].timeout);
+          typingTimeoutsRef.current.delete(roomTyping[message.message.user_id].timeout);
+          const updated = { ...roomTyping };
+          delete updated[message.message.user_id];
+          return { ...prev, [messageRoomId]: updated };
+        });
+
+        return;
+      }
+
+      if (messageRoomId == null) {
+        return;
+      }
+
+      switch (message.type) {
+        case "subscribed":
+          setOnlineUsersByRoom((prev) => ({
+            ...prev,
+            [messageRoomId]: message.online_users,
+          }));
+          break;
+        case "user_joined":
+          setOnlineUsersByRoom((prev) => {
+            const existingUsers = prev[messageRoomId] ?? [];
+            const alreadyExists = existingUsers.some((user) => user.id === message.user.id);
+            return {
+              ...prev,
+              [messageRoomId]: alreadyExists
+                ? existingUsers
+                : [...existingUsers, message.user],
+            };
+          });
+          break;
+        case "user_left":
+          setOnlineUsersByRoom((prev) => ({
+            ...prev,
+            [messageRoomId]: (prev[messageRoomId] ?? []).filter(
+              (user) => user.id !== message.user.id,
+            ),
+          }));
+          break;
+        case "typing_indicator": {
+          const { room_id: roomId, user } = message;
+
+          setTypingUsersByRoom((prev) => {
+            const roomTyping = { ...(prev[roomId] ?? {}) };
+            if (roomTyping[user.id]) {
+              clearTimeout(roomTyping[user.id].timeout);
+              typingTimeoutsRef.current.delete(roomTyping[user.id].timeout);
+            }
+
+            const timeout = setTimeout(() => {
+              setTypingUsersByRoom((current) => {
+                const nextRoomTyping = { ...(current[roomId] ?? {}) };
+                delete nextRoomTyping[user.id];
+                return { ...current, [roomId]: nextRoomTyping };
+              });
+              typingTimeoutsRef.current.delete(timeout);
+            }, 3000);
+
+            typingTimeoutsRef.current.add(timeout);
+            roomTyping[user.id] = { username: user.username, timeout };
+            return { ...prev, [roomId]: roomTyping };
+          });
+          break;
+        }
+      }
+    };
+
+    registerMessageHandler(handleMessage);
+    return () => registerMessageHandler(undefined);
+  }, [
+    registerMessageHandler,
+    selectedRoomRef,
+    setIncomingMessagesForRoom,
+    setLastReadAtByRoomId,
+    setOnlineUsersByRoom,
+    setTypingUsersByRoom,
+    setUnreadCounts,
+    setWsError,
+    subscribedRoomIdsRef,
+    tokenRef,
+    typingTimeoutsRef,
+  ]);
+}

--- a/frontend/src/hooks/useChatLayoutSubscriptions.ts
+++ b/frontend/src/hooks/useChatLayoutSubscriptions.ts
@@ -1,0 +1,65 @@
+import { useEffect, type Dispatch, type MutableRefObject, type SetStateAction } from "react";
+
+interface UseChatLayoutSubscriptionsParams {
+  connected: boolean;
+  subscribedRoomIds: number[];
+  subscribe: (roomId: number) => void;
+  setRefreshTrigger: Dispatch<SetStateAction<number>>;
+  subscribedSentRef: MutableRefObject<Set<number>>;
+  prevConnectedRef: MutableRefObject<boolean>;
+  hasConnectedOnceRef: MutableRefObject<boolean>;
+}
+
+export function useChatLayoutSubscriptions({
+  connected,
+  subscribedRoomIds,
+  subscribe,
+  setRefreshTrigger,
+  subscribedSentRef,
+  prevConnectedRef,
+  hasConnectedOnceRef,
+}: UseChatLayoutSubscriptionsParams): void {
+  useEffect(() => {
+    let refreshTimeoutId: number | undefined;
+
+    // Server subscriptions reset on reconnect, so we re-send local room subscriptions.
+    if (!prevConnectedRef.current && connected) {
+      subscribedSentRef.current.clear();
+      if (hasConnectedOnceRef.current) {
+        refreshTimeoutId = window.setTimeout(() => {
+          setRefreshTrigger((prev) => prev + 1);
+        }, 0);
+      }
+      hasConnectedOnceRef.current = true;
+    }
+    prevConnectedRef.current = connected;
+
+    return () => {
+      if (refreshTimeoutId) {
+        clearTimeout(refreshTimeoutId);
+      }
+    };
+  }, [connected, hasConnectedOnceRef, prevConnectedRef, setRefreshTrigger, subscribedSentRef]);
+
+  useEffect(() => {
+    if (!connected || subscribedRoomIds.length === 0) {
+      return;
+    }
+
+    subscribedRoomIds.forEach((roomId) => {
+      if (subscribedSentRef.current.has(roomId)) {
+        return;
+      }
+      subscribe(roomId);
+      subscribedSentRef.current.add(roomId);
+    });
+
+    // Remove any stale "sent" markers for rooms no longer tracked locally.
+    const subscribedIds = new Set(subscribedRoomIds);
+    subscribedSentRef.current.forEach((roomId) => {
+      if (!subscribedIds.has(roomId)) {
+        subscribedSentRef.current.delete(roomId);
+      }
+    });
+  }, [connected, subscribe, subscribedRoomIds, subscribedSentRef]);
+}

--- a/plans/task-frontend-component-refactor-03-chat-layout.md
+++ b/plans/task-frontend-component-refactor-03-chat-layout.md
@@ -50,3 +50,109 @@ cd frontend && npm test
 - [ ] PR references this issue (`Closes #...`).
 - [ ] Docs updated if needed (`docs/ARCHITECTURE.md`, `docs/PATTERNS.md`, `docs/REVIEW_CHECKLIST.md`, `backend/TESTPLAN.md`, `docs/adr/`).
 - [ ] Tests added/updated where needed.
+
+## Detailed Refactor Whiteboard (Pre-Implementation)
+
+### Current Responsibility Map (`ChatLayout.tsx`)
+- State orchestration:
+  - selected room, panel visibility, density, unread counts, read markers, typing users
+  - message view mode + context payload ownership
+  - incoming room message queue and processed callback handshake
+- Keyboard + page-level UX:
+  - global shortcuts (`Cmd/Ctrl+K`, `/`, `Escape`)
+  - search focus signal + command palette open/close signals
+  - document title updates from selected room
+- WebSocket event policy:
+  - handler registration lifecycle
+  - per-event branching for `new_message`, `subscribed`, `user_joined`, `user_left`, `typing_indicator`, `error`
+  - optimistic unread/read-marker updates and typing timeout bookkeeping
+- Subscription policy:
+  - room LRU list management with `MAX_SUBSCRIPTIONS` cap
+  - initial auto-subscribe on first room list load
+  - reconnect re-subscribe semantics + post-reconnect refresh trigger
+- Room cleanup/reset paths:
+  - duplicated leave/delete/no-token resets
+  - subscription + room-scoped state pruning (online users, unread, read markers, incoming queue)
+  - post-leave/post-delete room-list refresh trigger
+- Render composition:
+  - Sidebar / MessageArea / UsersPanel / SearchPanel wiring and callback contracts
+
+### Refactor Goals for This Task
+- Keep `ChatLayout` external behavior and child prop contracts unchanged.
+- Extract subscription/reconnect policy from component body into a focused hook.
+- Extract WS message-event handling orchestration into a focused hook/module while preserving stale-closure safety.
+- Centralize room cleanup/reset behavior for leave/delete paths in one helper to remove duplicated state teardown logic.
+
+### Planned File Changes
+- `frontend/src/components/ChatLayout.tsx` (reduce to state + composition container, keep public behavior stable)
+- `frontend/src/hooks/useChatLayoutSubscriptions.ts` (new; reconnect + subscribe/unsubscribe send policy)
+- `frontend/src/hooks/useChatLayoutMessageHandler.ts` (new; WS event handler registration and event-specific state transitions)
+- `frontend/src/components/chat-layout/chatLayoutRoomState.ts` (new; centralized room reset/cleanup helpers)
+- `frontend/src/components/__tests__/ChatLayout.test.tsx` (new; targeted orchestration regressions)
+
+### Hook/Helper Contract Drafts
+- `useChatLayoutSubscriptions`
+  - Inputs:
+    - `connected`
+    - `subscribedRoomIds`
+    - `subscribe`
+    - `setRefreshTrigger`
+    - `subscribedSentRef`
+    - `prevConnectedRef`
+    - `hasConnectedOnceRef`
+  - Behavior:
+    - clears sent-cache when WS reconnects
+    - schedules unread refresh trigger after reconnect (not initial connect)
+    - sends subscribe only for unsent room IDs
+    - prunes sent-cache entries for removed room IDs
+- `useChatLayoutMessageHandler`
+  - Inputs:
+    - `registerMessageHandler`
+    - refs: `selectedRoomRef`, `subscribedRoomIdsRef`, `tokenRef`, `typingTimeoutsRef`
+    - setters/actions for unread/read-marker/online users/incoming queue/ws error
+  - Outputs:
+    - none (side-effect hook)
+  - Non-functional requirements:
+    - preserve `registerMessageHandler` cleanup semantics (`undefined` on unmount)
+    - preserve 4s WS error auto-clear behavior
+    - preserve no-drop incoming append and typing-indicator timeout handling
+- `chatLayoutRoomState` helper(s)
+  - `clearSelectedRoomState(setters, roomId?)`
+    - centralizes normal/context reset + incoming queue clear
+    - optionally prunes room-scoped maps for a specific room id
+  - used by leave/delete/no-token paths to eliminate duplicated reset logic
+
+### Execution Steps (with verification checkpoints)
+1. Extract room cleanup/reset helpers and wire leave/delete/no-token branches to one shared path.
+   - Verify: targeted `ChatLayout` tests for leave/delete/reset semantics.
+2. Extract subscription/reconnect effects into `useChatLayoutSubscriptions`.
+   - Verify: tests for initial subscribe and reconnect refresh/subscribe behavior.
+3. Extract WS event handler registration into `useChatLayoutMessageHandler`.
+   - Verify: tests for WS error banner flow + unread updates for selected/non-selected rooms.
+4. Add/finish targeted regression tests and clean container imports/orphan logic.
+   - Verify: `npx tsc --noEmit`, `npx eslint src/`, `npm run build`, `npm test -- ChatLayout.test.tsx`, `npm test`.
+
+### Regression Guardrails (must stay true)
+- Shortcut semantics remain unchanged (`Cmd/Ctrl+K`, `/`, `Escape`).
+- Leave/delete flows still clear selection, unsubscribe room, and refresh room list.
+- Room selection still resets context mode and takes freshest read-marker snapshot behavior.
+- Selected-room incoming messages append to feed queue and trigger mark-read side effect.
+- Non-selected subscribed-room messages only increment unread counts.
+- Typing indicator state still auto-clears after 3 seconds and clears on sender message.
+- Reconnect still re-subscribes tracked rooms without duplicate subscribe sends.
+
+### Cross-Task Compatibility Checklist (`#17` -> `#18`)
+- [ ] `Sidebar` prop contract remains unchanged (including command palette signal counters).
+- [ ] `MessageArea` prop contract remains unchanged (including `incomingMessages` + processed callback).
+- [ ] `SearchPanel` open/focus/message-context integration semantics remain unchanged.
+- [ ] `roomOpenLastReadSnapshot` derivation timing remains unchanged for new-message divider stability.
+- [ ] `onInitialRoomsLoaded` one-time auto-subscribe ownership remains in `ChatLayout`.
+- [ ] Subscription cap semantics (`MAX_SUBSCRIPTIONS` LRU eviction behavior) remain unchanged.
+- [ ] No WebSocket payload shape assumptions or API service signatures are changed.
+- [ ] No `MessageList` or `MessageArea` internal behavior is altered beyond existing callbacks.
+
+### Test Additions Planned
+- Add regression test that leave-room flow unsubscribes selected room, clears selection, and bumps refresh trigger even when API leave fails.
+- Add regression test that room-delete callback uses centralized cleanup (unsubscribes + prunes room-scoped state + refresh trigger).
+- Add regression test that WS `error` messages render/dismiss via `MessageArea` banner wiring.
+- Add regression test that WS `new_message` increments unread for non-selected subscribed rooms while selected-room messages go to incoming queue.


### PR DESCRIPTION
## Summary
- extract WebSocket event handling from `ChatLayout` into `useChatLayoutMessageHandler`
- extract subscription/reconnect behavior into `useChatLayoutSubscriptions`
- centralize leave/delete room reset logic in `chatLayoutRoomState`
- add targeted `ChatLayout` orchestration regression tests
- append detailed pre-implementation whiteboard plan for Task #17

## Verification
- cd frontend && npx tsc --noEmit
- cd frontend && npx eslint src/
- cd frontend && npm run build
- cd frontend && npm test -- ChatLayout.test.tsx
- cd frontend && npm test

Closes #17