### PR TITLE
refactor: decompose MessageArea header/actions and delete modal

### DIFF
--- a/frontend/src/components/MessageArea.tsx
+++ b/frontend/src/components/MessageArea.tsx
@@ -8,6 +8,8 @@ import { deleteRoom } from "../services/api";
 import { logError } from "../utils/logger";
 import { formatRoomNameForDisplay } from "../utils/roomNames";
 import { useFocusTrap } from "../hooks/useFocusTrap";
+import { MessageAreaHeader } from "./message-area/MessageAreaHeader";
+import { DeleteRoomModal } from "./message-area/DeleteRoomModal";
 
 interface MessageAreaProps {
   selectedRoom: Room | null;
@@ -203,255 +205,37 @@ export default function MessageArea({
       className="flex-1 flex flex-col min-h-0 min-w-0 overflow-hidden"
       style={{ background: "var(--bg-app)" }}
     >
-      {/* Room Header */}
-      <div
-        className="shrink-0 flex items-center justify-between gap-2 px-3 sm:px-5 min-w-0"
-        style={{
-          borderBottom: "1px solid var(--border-dim)",
-          padding: "12px 20px",
+      <MessageAreaHeader
+        displayRoomName={displayRoomName}
+        theme={theme}
+        showRoomMenu={showRoomMenu}
+        hasOtherUnreadRooms={hasOtherUnreadRooms}
+        isRoomOwner={isRoomOwner}
+        onBackToRooms={onBackToRooms}
+        onToggleRoomMenu={() => setShowRoomMenu((prev) => !prev)}
+        onCloseRoomMenu={() => setShowRoomMenu(false)}
+        onLeaveRoom={() => {
+          setShowRoomMenu(false);
+          onLeaveRoom();
         }}
-      >
-        <div className="flex items-center gap-2.5 min-w-0 flex-1">
-          {/* Back button - mobile only */}
-          <div className="relative md:hidden">
-            <button
-              type="button"
-              data-tab-focus="back-button"
-              onClick={onBackToRooms}
-              className="shrink-0 transition-colors p-1 icon-button-focus"
-              style={{ color: "var(--color-meta)" }}
-              title="Back to rooms"
-              aria-label="Back to rooms"
-            >
-              <svg
-                className="w-6 h-6"
-                fill="none"
-                stroke="currentColor"
-                viewBox="0 0 24 24"
-              >
-                <path
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  strokeWidth={2}
-                  d="M15 19l-7-7 7-7"
-                />
-              </svg>
-            </button>
-            {hasOtherUnreadRooms && (
-              <span
-                className="absolute top-0 right-0 w-2 h-2 rounded-full"
-                style={{
-                  background: "var(--color-secondary)",
-                  boxShadow: "var(--glow-secondary)",
-                }}
-                aria-hidden
-              />
-            )}
-          </div>
+        onRequestDeleteRoom={() => {
+          setShowRoomMenu(false);
+          setDeleteError("");
+          setShowDeleteModal(true);
+        }}
+        onToggleSearch={onToggleSearch}
+        onToggleUsers={onToggleUsers}
+      />
 
-          <div className="min-w-0 flex-1 overflow-hidden">
-            {/* Room name — gradient for neon, solid glow for amber */}
-            {theme === "neon" ? (
-              <h2
-                className="inline-flex items-center max-w-full font-bebas text-[24px] leading-none tracking-[0.11em] truncate gradient-text"
-                title={`#${displayRoomName}`}
-                style={{
-                  backgroundImage:
-                    "linear-gradient(90deg, var(--color-primary), var(--color-secondary))",
-                  filter: "drop-shadow(0 0 6px rgba(0, 240, 255, 0.27))",
-                }}
-              >
-                #{displayRoomName}
-              </h2>
-            ) : (
-              <h2
-                className="inline-flex items-center max-w-full font-bebas text-[24px] leading-none tracking-[0.11em] truncate"
-                title={`#${displayRoomName}`}
-                style={{
-                  color: "var(--color-primary)",
-                  textShadow: "var(--glow-primary)",
-                }}
-              >
-                #{displayRoomName}
-              </h2>
-            )}
-          </div>
-
-          {/* Room Options Menu */}
-          <div className="relative shrink-0">
-            <button
-              type="button"
-              data-tab-focus="room-menu-button"
-              onClick={() => setShowRoomMenu(!showRoomMenu)}
-              className="transition-colors p-1.5 icon-button-focus"
-              style={{ color: "var(--color-meta)" }}
-              title="Room options"
-              aria-label="Room options"
-            >
-              <svg className="w-5 h-5" fill="currentColor" viewBox="0 0 24 24">
-                <path d="M12 8c1.1 0 2-.9 2-2s-.9-2-2-2-2 .9-2 2 .9 2 2 2zm0 2c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm0 6c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2z" />
-              </svg>
-            </button>
-
-            {/* Dropdown Menu */}
-            {showRoomMenu && (
-              <>
-                <div
-                  className="fixed inset-0 z-10 cursor-pointer"
-                  onClick={() => setShowRoomMenu(false)}
-                />
-                <div
-                  className="absolute right-0 mt-2 w-48 max-w-[calc(100vw-16px)] max-h-64 overflow-y-auto shadow-lg py-1 z-20"
-                  style={{
-                    background: "var(--bg-panel)",
-                    border: "1px solid var(--border-primary)",
-                  }}
-                >
-                  <button
-                    onClick={() => {
-                      setShowRoomMenu(false);
-                      onLeaveRoom();
-                    }}
-                    className="w-full px-4 py-2 text-left font-mono text-[12px] room-menu-item"
-                    style={{ color: "var(--color-text)" }}
-                  >
-                    Leave Room
-                  </button>
-
-                  {isRoomOwner && (
-                    <>
-                      <div style={{ borderTop: "1px solid var(--border-dim)", margin: "4px 0" }} />
-                      <button
-                        onClick={() => {
-                          setShowRoomMenu(false);
-                          setDeleteError("");
-                          setShowDeleteModal(true);
-                        }}
-                        className="w-full px-4 py-2 text-left font-mono text-[12px] room-menu-item"
-                        style={{ color: "#ff4444" }}
-                      >
-                        Delete Room
-                      </button>
-                    </>
-                  )}
-                </div>
-              </>
-            )}
-          </div>
-        </div>
-
-        {/* Search toggle */}
-        <button
-          type="button"
-          data-tab-focus="search-button"
-          onClick={onToggleSearch}
-          className="shrink-0 transition-colors p-1 icon-button-focus"
-          style={{ color: "var(--color-meta)" }}
-          title="Search messages"
-          aria-label="Search messages"
-        >
-          <svg
-            className="w-5 h-5"
-            fill="none"
-            stroke="currentColor"
-            viewBox="0 0 24 24"
-          >
-            <path
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              strokeWidth={2}
-              d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"
-            />
-          </svg>
-        </button>
-
-        <button
-          type="button"
-          data-tab-focus="users-button"
-          onClick={onToggleUsers}
-          className="shrink-0 transition-colors p-1 icon-button-focus"
-          style={{ color: "var(--color-meta)" }}
-          title="Toggle users panel"
-          aria-label="Toggle users panel"
-        >
-          <svg
-            className="w-6 h-6"
-            fill="none"
-            stroke="currentColor"
-            viewBox="0 0 24 24"
-          >
-            <path
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              strokeWidth={2}
-              d="M12 4.354a4 4 0 110 5.292M15 21H3v-1a6 6 0 0112 0v1zm0 0h6v-1a6 6 0 00-9-5.197M13 7a4 4 0 11-8 0 4 4 0 018 0z"
-            />
-          </svg>
-        </button>
-      </div>
-
-      {/* Delete Confirmation Modal */}
-      {showDeleteModal && (
-        <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
-          <div
-            ref={deleteModalRef}
-            role="dialog"
-            aria-modal="true"
-            aria-labelledby="delete-room-title"
-            className="p-6 max-w-md w-full mx-4"
-            style={{
-              background: "var(--bg-panel)",
-              border: "1px solid var(--border-primary)",
-            }}
-          >
-            <h3
-              id="delete-room-title"
-              className="font-bebas text-[22px] tracking-[0.08em] mb-2"
-              style={{ color: "var(--color-primary)" }}
-            >
-              Delete Room?
-            </h3>
-            <p className="font-mono text-[14px] mb-6" style={{ color: "var(--color-meta)" }}>
-              Are you sure you want to delete{" "}
-              <span style={{ color: "var(--color-primary)" }}>
-                {displayRoomName}
-              </span>
-              ? This will permanently delete all messages. This action cannot be undone.
-            </p>
-            {deleteError && (
-              <p className="text-sm mb-4" style={{ color: "#ff4444" }}>{deleteError}</p>
-            )}
-            <div className="flex gap-3 justify-end">
-              <button
-                onClick={() => {
-                  closeDeleteModal();
-                }}
-                disabled={deleting}
-                className="px-4 py-2 font-bebas text-[14px] tracking-[0.10em] transition-colors disabled:opacity-50"
-                style={{
-                  border: "1px solid var(--border-dim)",
-                  color: "var(--color-text)",
-                  background: "transparent",
-                }}
-              >
-                CANCEL
-              </button>
-              <button
-                onClick={handleDeleteRoom}
-                disabled={deleting}
-                className="px-4 py-2 font-bebas text-[14px] tracking-[0.10em] transition-colors disabled:opacity-50"
-                style={{
-                  background: "#ff4444",
-                  color: "#000",
-                  border: "1px solid #ff4444",
-                }}
-              >
-                {deleting ? "DELETING..." : "DELETE ROOM"}
-              </button>
-            </div>
-          </div>
-        </div>
-      )}
+      <DeleteRoomModal
+        open={showDeleteModal}
+        displayRoomName={displayRoomName}
+        deleting={deleting}
+        deleteError={deleteError}
+        modalRef={deleteModalRef}
+        onCancel={closeDeleteModal}
+        onConfirm={handleDeleteRoom}
+      />
 
       <MessageList
         key={selectedRoom.id}

--- a/frontend/src/components/__tests__/MessageArea.test.tsx
+++ b/frontend/src/components/__tests__/MessageArea.test.tsx
@@ -111,6 +111,26 @@ describe("MessageArea", () => {
     expect(screen.getByRole("button", { name: "Delete Room" })).toBeInTheDocument();
   });
 
+  it("calls mobile back callback from header button", async () => {
+    const user = userEvent.setup();
+    renderMessageArea();
+
+    await user.click(screen.getByRole("button", { name: "Back to rooms" }));
+
+    expect(mockOnBackToRooms).toHaveBeenCalledTimes(1);
+  });
+
+  it("calls search and users header actions", async () => {
+    const user = userEvent.setup();
+    renderMessageArea();
+
+    await user.click(screen.getByRole("button", { name: "Search messages" }));
+    await user.click(screen.getByRole("button", { name: "Toggle users panel" }));
+
+    expect(mockOnToggleSearch).toHaveBeenCalledTimes(1);
+    expect(mockOnToggleUsers).toHaveBeenCalledTimes(1);
+  });
+
   it("hides delete option for non-room-owner", async () => {
     const user = userEvent.setup();
     renderMessageArea({
@@ -172,6 +192,7 @@ describe("MessageArea", () => {
       expect(mockOnRoomDeleted).toHaveBeenCalledTimes(1);
     });
     expect(mockDeleteRoom).toHaveBeenCalledWith(10, "test-token");
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
   });
 
   it("shows inline delete error on API failure", async () => {
@@ -188,7 +209,20 @@ describe("MessageArea", () => {
     await user.click(screen.getByRole("button", { name: "DELETE ROOM" }));
 
     expect(await screen.findByText("Delete failed")).toBeInTheDocument();
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
     expect(consoleErrorSpy).toHaveBeenCalled();
+  });
+
+  it("closes delete modal when cancel is clicked", async () => {
+    const user = userEvent.setup();
+    renderMessageArea();
+
+    await user.click(screen.getByRole("button", { name: "Room options" }));
+    await user.click(screen.getByRole("button", { name: "Delete Room" }));
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "CANCEL" }));
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
   });
 
   it("supports typing indicator text formats", () => {

--- a/frontend/src/components/message-area/DeleteRoomModal.tsx
+++ b/frontend/src/components/message-area/DeleteRoomModal.tsx
@@ -1,0 +1,87 @@
+import type { RefObject } from "react";
+
+interface DeleteRoomModalProps {
+  open: boolean;
+  displayRoomName: string;
+  deleting: boolean;
+  deleteError: string;
+  modalRef: RefObject<HTMLDivElement | null>;
+  onCancel: () => void;
+  onConfirm: () => void;
+}
+
+export function DeleteRoomModal({
+  open,
+  displayRoomName,
+  deleting,
+  deleteError,
+  modalRef,
+  onCancel,
+  onConfirm,
+}: DeleteRoomModalProps) {
+  if (!open) {
+    return null;
+  }
+
+  return (
+    <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
+      <div
+        ref={modalRef}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="delete-room-title"
+        className="p-6 max-w-md w-full mx-4"
+        style={{
+          background: "var(--bg-panel)",
+          border: "1px solid var(--border-primary)",
+        }}
+      >
+        <h3
+          id="delete-room-title"
+          className="font-bebas text-[22px] tracking-[0.08em] mb-2"
+          style={{ color: "var(--color-primary)" }}
+        >
+          Delete Room?
+        </h3>
+        <p className="font-mono text-[14px] mb-6" style={{ color: "var(--color-meta)" }}>
+          Are you sure you want to delete{" "}
+          <span style={{ color: "var(--color-primary)" }}>
+            {displayRoomName}
+          </span>
+          ? This will permanently delete all messages. This action cannot be undone.
+        </p>
+        {deleteError && (
+          <p className="text-sm mb-4" style={{ color: "#ff4444" }}>{deleteError}</p>
+        )}
+        <div className="flex gap-3 justify-end">
+          <button
+            type="button"
+            onClick={onCancel}
+            disabled={deleting}
+            className="px-4 py-2 font-bebas text-[14px] tracking-[0.10em] transition-colors disabled:opacity-50"
+            style={{
+              border: "1px solid var(--border-dim)",
+              color: "var(--color-text)",
+              background: "transparent",
+            }}
+          >
+            CANCEL
+          </button>
+          <button
+            type="button"
+            onClick={onConfirm}
+            disabled={deleting}
+            className="px-4 py-2 font-bebas text-[14px] tracking-[0.10em] transition-colors disabled:opacity-50"
+            style={{
+              background: "#ff4444",
+              color: "#000",
+              border: "1px solid #ff4444",
+            }}
+          >
+            {deleting ? "DELETING..." : "DELETE ROOM"}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/message-area/MessageAreaHeader.tsx
+++ b/frontend/src/components/message-area/MessageAreaHeader.tsx
@@ -1,0 +1,212 @@
+interface MessageAreaHeaderProps {
+  displayRoomName: string;
+  theme: "neon" | "amber";
+  showRoomMenu: boolean;
+  hasOtherUnreadRooms: boolean;
+  isRoomOwner: boolean;
+  onBackToRooms: () => void;
+  onToggleRoomMenu: () => void;
+  onCloseRoomMenu: () => void;
+  onLeaveRoom: () => void;
+  onRequestDeleteRoom: () => void;
+  onToggleSearch: () => void;
+  onToggleUsers: () => void;
+}
+
+export function MessageAreaHeader({
+  displayRoomName,
+  theme,
+  showRoomMenu,
+  hasOtherUnreadRooms,
+  isRoomOwner,
+  onBackToRooms,
+  onToggleRoomMenu,
+  onCloseRoomMenu,
+  onLeaveRoom,
+  onRequestDeleteRoom,
+  onToggleSearch,
+  onToggleUsers,
+}: MessageAreaHeaderProps) {
+  return (
+    <div
+      className="shrink-0 flex items-center justify-between gap-2 px-3 sm:px-5 min-w-0"
+      style={{
+        borderBottom: "1px solid var(--border-dim)",
+        padding: "12px 20px",
+      }}
+    >
+      <div className="flex items-center gap-2.5 min-w-0 flex-1">
+        {/* Back button - mobile only */}
+        <div className="relative md:hidden">
+          <button
+            type="button"
+            data-tab-focus="back-button"
+            onClick={onBackToRooms}
+            className="shrink-0 transition-colors p-1 icon-button-focus"
+            style={{ color: "var(--color-meta)" }}
+            title="Back to rooms"
+            aria-label="Back to rooms"
+          >
+            <svg
+              className="w-6 h-6"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M15 19l-7-7 7-7"
+              />
+            </svg>
+          </button>
+          {hasOtherUnreadRooms && (
+            <span
+              className="absolute top-0 right-0 w-2 h-2 rounded-full"
+              style={{
+                background: "var(--color-secondary)",
+                boxShadow: "var(--glow-secondary)",
+              }}
+              aria-hidden
+            />
+          )}
+        </div>
+
+        <div className="min-w-0 flex-1 overflow-hidden">
+          {/* Room name — gradient for neon, solid glow for amber */}
+          {theme === "neon" ? (
+            <h2
+              className="inline-flex items-center max-w-full font-bebas text-[24px] leading-none tracking-[0.11em] truncate gradient-text"
+              title={`#${displayRoomName}`}
+              style={{
+                backgroundImage:
+                  "linear-gradient(90deg, var(--color-primary), var(--color-secondary))",
+                filter: "drop-shadow(0 0 6px rgba(0, 240, 255, 0.27))",
+              }}
+            >
+              #{displayRoomName}
+            </h2>
+          ) : (
+            <h2
+              className="inline-flex items-center max-w-full font-bebas text-[24px] leading-none tracking-[0.11em] truncate"
+              title={`#${displayRoomName}`}
+              style={{
+                color: "var(--color-primary)",
+                textShadow: "var(--glow-primary)",
+              }}
+            >
+              #{displayRoomName}
+            </h2>
+          )}
+        </div>
+
+        {/* Room Options Menu */}
+        <div className="relative shrink-0">
+          <button
+            type="button"
+            data-tab-focus="room-menu-button"
+            onClick={onToggleRoomMenu}
+            className="transition-colors p-1.5 icon-button-focus"
+            style={{ color: "var(--color-meta)" }}
+            title="Room options"
+            aria-label="Room options"
+          >
+            <svg className="w-5 h-5" fill="currentColor" viewBox="0 0 24 24">
+              <path d="M12 8c1.1 0 2-.9 2-2s-.9-2-2-2-2 .9-2 2 .9 2 2 2zm0 2c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm0 6c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2z" />
+            </svg>
+          </button>
+
+          {/* Dropdown Menu */}
+          {showRoomMenu && (
+            <>
+              <div
+                className="fixed inset-0 z-10 cursor-pointer"
+                onClick={onCloseRoomMenu}
+              />
+              <div
+                className="absolute right-0 mt-2 w-48 max-w-[calc(100vw-16px)] max-h-64 overflow-y-auto shadow-lg py-1 z-20"
+                style={{
+                  background: "var(--bg-panel)",
+                  border: "1px solid var(--border-primary)",
+                }}
+              >
+                <button
+                  type="button"
+                  onClick={onLeaveRoom}
+                  className="w-full px-4 py-2 text-left font-mono text-[12px] room-menu-item"
+                  style={{ color: "var(--color-text)" }}
+                >
+                  Leave Room
+                </button>
+
+                {isRoomOwner && (
+                  <>
+                    <div style={{ borderTop: "1px solid var(--border-dim)", margin: "4px 0" }} />
+                    <button
+                      type="button"
+                      onClick={onRequestDeleteRoom}
+                      className="w-full px-4 py-2 text-left font-mono text-[12px] room-menu-item"
+                      style={{ color: "#ff4444" }}
+                    >
+                      Delete Room
+                    </button>
+                  </>
+                )}
+              </div>
+            </>
+          )}
+        </div>
+      </div>
+
+      {/* Search toggle */}
+      <button
+        type="button"
+        data-tab-focus="search-button"
+        onClick={onToggleSearch}
+        className="shrink-0 transition-colors p-1 icon-button-focus"
+        style={{ color: "var(--color-meta)" }}
+        title="Search messages"
+        aria-label="Search messages"
+      >
+        <svg
+          className="w-5 h-5"
+          fill="none"
+          stroke="currentColor"
+          viewBox="0 0 24 24"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth={2}
+            d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"
+          />
+        </svg>
+      </button>
+
+      <button
+        type="button"
+        data-tab-focus="users-button"
+        onClick={onToggleUsers}
+        className="shrink-0 transition-colors p-1 icon-button-focus"
+        style={{ color: "var(--color-meta)" }}
+        title="Toggle users panel"
+        aria-label="Toggle users panel"
+      >
+        <svg
+          className="w-6 h-6"
+          fill="none"
+          stroke="currentColor"
+          viewBox="0 0 24 24"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth={2}
+            d="M12 4.354a4 4 0 110 5.292M15 21H3v-1a6 6 0 0112 0v1zm0 0h6v-1a6 6 0 00-9-5.197M13 7a4 4 0 11-8 0 4 4 0 018 0z"
+          />
+        </svg>
+      </button>
+    </div>
+  );
+}

--- a/plans/task-frontend-component-refactor-04-message-area.md
+++ b/plans/task-frontend-component-refactor-04-message-area.md
@@ -52,3 +52,104 @@ cd frontend && npm test
 - [ ] PR references this issue (`Closes #...`).
 - [ ] Docs updated if needed (`docs/ARCHITECTURE.md`, `docs/PATTERNS.md`, `docs/REVIEW_CHECKLIST.md`, `backend/TESTPLAN.md`, `docs/adr/`).
 - [ ] Tests added/updated where needed.
+
+## Detailed Refactor Whiteboard (Pre-Implementation)
+
+### Current Responsibility Map (`MessageArea.tsx`)
+- Empty-state rendering:
+  - welcome panel when no room is selected
+  - theme-specific heading rendering
+- Header rendering + interaction orchestration:
+  - mobile back button with unread-dot affordance
+  - room title formatting/styling
+  - room options trigger + dropdown visibility lifecycle
+  - room menu actions (leave + owner-only delete entry)
+  - search/users action buttons
+- Destructive action orchestration:
+  - delete modal open/close lifecycle
+  - delete mutation state (`deleting`, `deleteError`)
+  - success path (`onRoomDeleted`) and inline error path
+  - focus trap + Escape/overlay close behavior
+- Keyboard behavior:
+  - Escape handling for room menu dismiss
+  - custom tab-order routing for input/send/back/menu/search/users controls
+- Message feed/input wiring:
+  - `MessageList` contract passthrough
+  - `scrollToLatestSignal` ownership for local sends
+  - `MessageInput` contract passthrough
+- Room-level status rows:
+  - typing indicator row text formatting + fixed-height layout reservation
+  - ephemeral WebSocket error row + dismiss action
+
+### Refactor Goals for This Task
+- Keep `MessageArea` public props and all parent-visible behavior unchanged.
+- Extract header/menu actions into dedicated message-area components.
+- Extract delete confirmation modal into a dedicated message-area component.
+- Keep typing indicator row and WS error row logic inside `MessageArea` for this task.
+
+### Planned File Changes
+- `frontend/src/components/MessageArea.tsx` (reduce to container/composition + retained status-row behavior)
+- `frontend/src/components/message-area/MessageAreaHeader.tsx` (new; room header + action controls + room options menu)
+- `frontend/src/components/message-area/DeleteRoomModal.tsx` (new; destructive confirmation UI and inline error rendering)
+- `frontend/src/components/__tests__/MessageArea.test.tsx` (update/add targeted header/mobile/delete-flow regressions)
+
+### Hook/Component Contract Drafts
+- `MessageAreaHeader`
+  - Inputs:
+    - `displayRoomName`
+    - `theme`
+    - `showRoomMenu`
+    - `hasOtherUnreadRooms`
+    - `isRoomOwner`
+    - callbacks: `onBackToRooms`, `onToggleRoomMenu`, `onCloseRoomMenu`, `onLeaveRoom`, `onRequestDeleteRoom`, `onToggleSearch`, `onToggleUsers`
+  - Behavior preserved:
+    - mobile back button semantics and unread dot rendering
+    - room options menu open/close and leave/delete actions
+    - search/users callbacks unchanged
+    - room title rendering parity for neon/amber themes
+- `DeleteRoomModal`
+  - Inputs:
+    - `open`
+    - `displayRoomName`
+    - `deleting`
+    - `deleteError`
+    - `modalRef` (for existing focus trap hook integration)
+    - callbacks: `onCancel`, `onConfirm`
+  - Behavior preserved:
+    - cancel disabled while deleting
+    - destructive button text swap (`DELETE ROOM` / `DELETING...`)
+    - inline error message rendering
+    - dialog semantics (`role=dialog`, `aria-modal`, title linkage)
+
+### Execution Steps (with verification checkpoints)
+1. Add `MessageAreaHeader` and move header/menu JSX + callbacks without changing `MessageArea` public props.
+   - Verify: targeted tests for room options actions and mobile back behavior.
+2. Add `DeleteRoomModal` and move delete-modal JSX while retaining existing delete state/mutation flow in `MessageArea`.
+   - Verify: targeted tests for successful delete, failure inline error, and cancel/close behavior.
+3. Keep typing/ws-error rows in `MessageArea`, remove orphaned header/modal logic, and ensure no contract drift with `ChatLayout`.
+   - Verify: `npx tsc --noEmit`, `npx eslint src/`, `npm run build`, `npm test -- MessageArea.test.tsx`, `npm test`.
+
+### Regression Guardrails (must stay true)
+- `MessageAreaProps` external shape and semantics are unchanged.
+- Mobile back button still calls `onBackToRooms` and keeps unread indicator behavior.
+- Room menu still supports Escape close, overlay close, leave action, and owner-only delete action.
+- Delete flow still calls `deleteRoom(roomId, token)` and only fires `onRoomDeleted` on success.
+- Delete API failure still renders inline modal error (no alert/dialog fallback).
+- `MessageList`/`MessageInput` wiring and `scrollToLatestSignal` behavior remain unchanged.
+- Typing indicator row and WS error row remain in `MessageArea` with identical behavior.
+
+### Cross-Task Compatibility Checklist (`#17` -> `#18`)
+- [ ] `ChatLayout` -> `MessageArea` prop contract remains unchanged (no prop rename/removal/semantic shift).
+- [ ] `onBackToRooms` flow still interoperates with `ChatLayout` mobile sidebar behavior.
+- [ ] `onRoomDeleted` and `onLeaveRoom` callbacks still trigger existing room-reset orchestration in `ChatLayout`.
+- [ ] `incomingMessages` + `onIncomingMessagesProcessed` contract remains unchanged for `MessageList`.
+- [ ] Context-mode props (`messageViewMode`, `messageContext`, `onExitContextMode`) pass through unchanged.
+- [ ] `wsError` + `onDismissWsError` wiring remains unchanged.
+- [ ] No API service signature or WebSocket payload assumptions are changed.
+
+### Test Additions Planned
+- Add regression test that mobile back button calls `onBackToRooms`.
+- Add regression test that header action buttons still call `onToggleSearch` and `onToggleUsers`.
+- Add regression test that owner delete flow opens modal and confirm path calls API + `onRoomDeleted`.
+- Add regression test that delete failure preserves modal visibility and inline error text.
+- Keep/adjust existing tests that cover room menu Escape close, leave-room callback, typing indicator text, and WS error dismiss.


### PR DESCRIPTION
## Summary
- decompose MessageArea by extracting room header/menu actions into MessageAreaHeader
- extract destructive confirmation UI into DeleteRoomModal while keeping delete orchestration in MessageArea
- preserve typing indicator row and ephemeral WS error row behavior in MessageArea
- add targeted regressions for mobile back, header action callbacks, and destructive modal flows
- append detailed pre-implementation whiteboard plan for Task #18

## Verification
- cd frontend && npx tsc --noEmit
- cd frontend && npx eslint src/
- cd frontend && npm run build
- cd frontend && npm test -- MessageArea.test.tsx
- cd frontend && npm test

Closes #18