### PR TITLE
refactor: decompose ChatLayout shortcut and ui effects

### DIFF
--- a/frontend/src/components/ChatLayout.tsx
+++ b/frontend/src/components/ChatLayout.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef } from "react";
+import { useState, useEffect, useRef, useCallback } from "react";
 import Sidebar from "./Sidebar";
 import MessageArea from "./MessageArea";
 import UsersPanel from "./UsersPanel";
@@ -6,9 +6,10 @@ import SearchPanel from "./SearchPanel";
 import { useWebSocketContext } from "../context/useWebSocketContext";
 import { useAuth } from "../context/AuthContext";
 import { markRoomRead, leaveRoom } from "../services/api";
-import { formatRoomNameForDisplay } from "../utils/roomNames";
 import { useChatLayoutMessageHandler } from "../hooks/useChatLayoutMessageHandler";
 import { useChatLayoutSubscriptions } from "../hooks/useChatLayoutSubscriptions";
+import { useChatLayoutShortcuts } from "../hooks/useChatLayoutShortcuts";
+import { useChatLayoutUiEffects } from "../hooks/useChatLayoutUiEffects";
 import {
   clearRoomScopedState,
   resetSelectedRoomState,
@@ -19,13 +20,6 @@ const MAX_SUBSCRIPTIONS = 10;
 const INITIAL_AUTO_SUBSCRIBE_COUNT = 5;
 type UiDensity = "compact" | "comfortable";
 type MessageViewMode = "normal" | "context";
-
-function isTypingTarget(target: EventTarget | null): boolean {
-  if (!(target instanceof HTMLElement)) return false;
-  return Boolean(
-    target.closest("input, textarea, select, [contenteditable='true']"),
-  );
-}
 
 function parseIsoTimestamp(value: string | null | undefined): number | null {
   if (!value) return null;
@@ -130,55 +124,35 @@ export default function ChatLayout() {
     tokenRef.current = token;
   }, [token]);
 
-  useEffect(() => {
-    localStorage.setItem("rostra-density", density);
-  }, [density]);
+  const handleOpenCommandPalette = useCallback(() => {
+    setOpenCommandPaletteSignal((prev) => prev + 1);
+  }, []);
 
-  useEffect(() => {
-    if (!selectedRoom) {
-      document.title = "Rostra";
-      return;
-    }
+  const handleCloseCommandPalette = useCallback(() => {
+    setCloseCommandPaletteSignal((prev) => prev + 1);
+  }, []);
 
-    const roomName = formatRoomNameForDisplay(selectedRoom.name);
-    document.title = `#${roomName} - Rostra`;
-  }, [selectedRoom]);
+  const handleOpenSearchPanel = useCallback(() => {
+    setRightPanel("search");
+    setSearchFocusSignal((prev) => prev + 1);
+  }, []);
 
-  useEffect(() => {
-    const handleGlobalShortcuts = (event: KeyboardEvent) => {
-      if (
-        (event.metaKey || event.ctrlKey) &&
-        event.key.toLowerCase() === "k"
-      ) {
-        event.preventDefault();
-        setOpenCommandPaletteSignal((prev) => prev + 1);
-        return;
-      }
+  const handleCloseRightPanel = useCallback(() => {
+    setRightPanel("none");
+  }, []);
 
-      if (isTypingTarget(event.target)) return;
+  useChatLayoutUiEffects({
+    selectedRoom,
+    density,
+  });
 
-      if (
-        event.key === "/" &&
-        !event.metaKey &&
-        !event.ctrlKey &&
-        !event.altKey &&
-        selectedRoom
-      ) {
-        event.preventDefault();
-        setRightPanel("search");
-        setSearchFocusSignal((prev) => prev + 1);
-        return;
-      }
-
-      if (event.key === "Escape") {
-        setRightPanel("none");
-        setCloseCommandPaletteSignal((prev) => prev + 1);
-      }
-    };
-
-    window.addEventListener("keydown", handleGlobalShortcuts);
-    return () => window.removeEventListener("keydown", handleGlobalShortcuts);
-  }, [selectedRoom]);
+  useChatLayoutShortcuts({
+    selectedRoom,
+    onOpenCommandPalette: handleOpenCommandPalette,
+    onCloseCommandPalette: handleCloseCommandPalette,
+    onOpenSearchPanel: handleOpenSearchPanel,
+    onCloseRightPanel: handleCloseRightPanel,
+  });
 
   useChatLayoutMessageHandler({
     registerMessageHandler,

--- a/frontend/src/components/__tests__/ChatLayout.test.tsx
+++ b/frontend/src/components/__tests__/ChatLayout.test.tsx
@@ -30,6 +30,8 @@ type SidebarMockProps = {
   onSelectRoom: (room: Room) => void;
   refreshTrigger: number;
   unreadCounts: Record<number, number>;
+  openCommandPaletteSignal: number;
+  closeCommandPaletteSignal: number;
 };
 
 type MessageAreaMockProps = {
@@ -44,8 +46,14 @@ type UsersPanelMockProps = {
   onlineUsers: Array<{ id: number; username: string }>;
 };
 
+type SearchPanelMockProps = {
+  isOpen: boolean;
+  focusSignal: number;
+};
+
 let latestSidebarProps: SidebarMockProps | null = null;
 let latestUsersPanelProps: UsersPanelMockProps | null = null;
+let latestSearchPanelProps: SearchPanelMockProps | null = null;
 let wsMessageHandler: ((message: WebSocketMessage) => void) | undefined;
 
 vi.mock("../../context/AuthContext", () => ({
@@ -85,6 +93,9 @@ vi.mock("../Sidebar", () => ({
     return (
       <div>
         <div data-testid="refresh-trigger">{props.refreshTrigger}</div>
+        <div data-testid="open-command-signal">{props.openCommandPaletteSignal}</div>
+        <div data-testid="close-command-signal">{props.closeCommandPaletteSignal}</div>
+        <input aria-label="Typing Target" />
         <button type="button" onClick={() => props.onSelectRoom(roomOne)}>
           Select Room One
         </button>
@@ -126,7 +137,15 @@ vi.mock("../UsersPanel", () => ({
 }));
 
 vi.mock("../SearchPanel", () => ({
-  default: () => null,
+  default: (props: SearchPanelMockProps) => {
+    latestSearchPanelProps = props;
+    return (
+      <div>
+        <div data-testid="search-open">{props.isOpen ? "open" : "closed"}</div>
+        <div data-testid="search-focus-signal">{props.focusSignal}</div>
+      </div>
+    );
+  },
 }));
 
 function emitWsMessage(message: WebSocketMessage) {
@@ -147,6 +166,7 @@ describe("ChatLayout", () => {
     mockLogout.mockReset();
     latestSidebarProps = null;
     latestUsersPanelProps = null;
+    latestSearchPanelProps = null;
     wsMessageHandler = undefined;
     mockMarkRoomRead.mockResolvedValue({ last_read_at: "2024-01-02T00:00:00" });
     mockLeaveRoom.mockResolvedValue({ room_id: 1 });
@@ -279,5 +299,63 @@ describe("ChatLayout", () => {
     });
 
     expect(screen.getByTestId("ws-error-text")).toHaveTextContent("");
+  });
+
+  it("opens command palette signal on Cmd/Ctrl+K", () => {
+    render(<ChatLayout />);
+
+    fireEvent.keyDown(window, { key: "k", ctrlKey: true });
+
+    expect(screen.getByTestId("open-command-signal")).toHaveTextContent("1");
+  });
+
+  it("opens search panel on slash when a room is selected", async () => {
+    render(<ChatLayout />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Select Room One" }));
+    await waitFor(() => {
+      expect(screen.getByTestId("selected-room-id")).toHaveTextContent("1");
+    });
+    expect(screen.getByTestId("search-open")).toHaveTextContent("closed");
+
+    fireEvent.keyDown(window, { key: "/" });
+
+    expect(screen.getByTestId("search-open")).toHaveTextContent("open");
+    expect(screen.getByTestId("search-focus-signal")).toHaveTextContent("1");
+    expect(latestSearchPanelProps?.isOpen).toBe(true);
+  });
+
+  it("does not open search panel on slash while typing in an input target", async () => {
+    render(<ChatLayout />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Select Room One" }));
+    await waitFor(() => {
+      expect(screen.getByTestId("selected-room-id")).toHaveTextContent("1");
+    });
+    expect(screen.getByTestId("search-open")).toHaveTextContent("closed");
+
+    const typingInput = screen.getByLabelText("Typing Target");
+    typingInput.focus();
+    fireEvent.keyDown(typingInput, { key: "/" });
+
+    expect(screen.getByTestId("search-open")).toHaveTextContent("closed");
+    expect(screen.getByTestId("search-focus-signal")).toHaveTextContent("0");
+  });
+
+  it("escape closes right panel and emits close command palette signal", async () => {
+    render(<ChatLayout />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Select Room One" }));
+    await waitFor(() => {
+      expect(screen.getByTestId("selected-room-id")).toHaveTextContent("1");
+    });
+
+    fireEvent.keyDown(window, { key: "/" });
+    expect(screen.getByTestId("search-open")).toHaveTextContent("open");
+
+    fireEvent.keyDown(window, { key: "Escape" });
+
+    expect(screen.getByTestId("search-open")).toHaveTextContent("closed");
+    expect(screen.getByTestId("close-command-signal")).toHaveTextContent("1");
   });
 });

--- a/frontend/src/hooks/useChatLayoutShortcuts.ts
+++ b/frontend/src/hooks/useChatLayoutShortcuts.ts
@@ -1,0 +1,66 @@
+import { useEffect } from "react";
+import type { Room } from "../types";
+
+interface UseChatLayoutShortcutsParams {
+  selectedRoom: Room | null;
+  onOpenCommandPalette: () => void;
+  onCloseCommandPalette: () => void;
+  onOpenSearchPanel: () => void;
+  onCloseRightPanel: () => void;
+}
+
+function isTypingTarget(target: EventTarget | null): boolean {
+  if (!(target instanceof HTMLElement)) return false;
+  return Boolean(
+    target.closest("input, textarea, select, [contenteditable='true']"),
+  );
+}
+
+export function useChatLayoutShortcuts({
+  selectedRoom,
+  onOpenCommandPalette,
+  onCloseCommandPalette,
+  onOpenSearchPanel,
+  onCloseRightPanel,
+}: UseChatLayoutShortcutsParams) {
+  useEffect(() => {
+    const handleGlobalShortcuts = (event: KeyboardEvent) => {
+      if (
+        (event.metaKey || event.ctrlKey) &&
+        event.key.toLowerCase() === "k"
+      ) {
+        event.preventDefault();
+        onOpenCommandPalette();
+        return;
+      }
+
+      if (isTypingTarget(event.target)) return;
+
+      if (
+        event.key === "/" &&
+        !event.metaKey &&
+        !event.ctrlKey &&
+        !event.altKey &&
+        selectedRoom
+      ) {
+        event.preventDefault();
+        onOpenSearchPanel();
+        return;
+      }
+
+      if (event.key === "Escape") {
+        onCloseRightPanel();
+        onCloseCommandPalette();
+      }
+    };
+
+    window.addEventListener("keydown", handleGlobalShortcuts);
+    return () => window.removeEventListener("keydown", handleGlobalShortcuts);
+  }, [
+    onCloseCommandPalette,
+    onCloseRightPanel,
+    onOpenCommandPalette,
+    onOpenSearchPanel,
+    selectedRoom,
+  ]);
+}

--- a/frontend/src/hooks/useChatLayoutUiEffects.ts
+++ b/frontend/src/hooks/useChatLayoutUiEffects.ts
@@ -1,0 +1,29 @@
+import { useEffect } from "react";
+import type { Room } from "../types";
+import { formatRoomNameForDisplay } from "../utils/roomNames";
+
+type UiDensity = "compact" | "comfortable";
+
+interface UseChatLayoutUiEffectsParams {
+  selectedRoom: Room | null;
+  density: UiDensity;
+}
+
+export function useChatLayoutUiEffects({
+  selectedRoom,
+  density,
+}: UseChatLayoutUiEffectsParams) {
+  useEffect(() => {
+    localStorage.setItem("rostra-density", density);
+  }, [density]);
+
+  useEffect(() => {
+    if (!selectedRoom) {
+      document.title = "Rostra";
+      return;
+    }
+
+    const roomName = formatRoomNameForDisplay(selectedRoom.name);
+    document.title = `#${roomName} - Rostra`;
+  }, [selectedRoom]);
+}


### PR DESCRIPTION
## Summary
- extract global keyboard shortcut handling from ChatLayout into useChatLayoutShortcuts
- extract density persistence + document-title effects into useChatLayoutUiEffects
- keep ChatLayout as orchestration/composition container with existing child contracts unchanged
- add targeted ChatLayout regressions for Cmd/Ctrl+K, slash-to-search, typing-target guard, and Escape close behavior
- bring frontend/src/components/ChatLayout.tsx under LOC cap (448)

## Verification
- cd frontend && npx tsc --noEmit
- cd frontend && npx eslint src/
- cd frontend && npm run build
- cd frontend && npm test -- ChatLayout.test.tsx
- cd frontend && npm test

Closes #24