### PR TITLE
docs: frontend commenting/documentation pass (#26)

### DIFF
--- a/docs/PATTERNS.md
+++ b/docs/PATTERNS.md
@@ -79,6 +79,12 @@ Reusable code patterns and conventions in this project. All of the following are
 - **Contract stability rule:** During refactors, keep parent/child public prop contracts stable unless the task explicitly scopes a contract change and includes test updates for it.
 - **Refactor verification rule:** Extraction-only PRs should preserve behavior and include targeted regression tests for high-risk interactions (keyboard flow, unread counters, modal flows, scroll/feed behavior).
 
+## Frontend Commenting Pattern
+
+- **Module responsibility header (complex files):** For orchestration-heavy files (for example ChatLayout, feed lifecycle hooks, websocket transport/context), start with a short comment describing ownership boundaries and major side effects.
+- **Invariant comments over mechanics:** Comment non-obvious guardrails (for example deduped WS subscriptions, read-marker authority, scroll anchor stability), not line-by-line syntax.
+- **Render vs orchestration ownership:** In render helpers/components, document when a value is read-only display state computed upstream (for example message divider anchors) to avoid accidental logic drift.
+
 ## WebSocket Pattern
 
 - **Service class:** `WebSocketService` in `services/websocket.ts`. Constructor takes token; `connect()` builds URL `ws(s)://host/ws/connect?token=<token>`. Base URL resolves from `VITE_WS_URL` when present, otherwise derives from `VITE_API_URL` (with optional `/api` suffix stripped). Before connecting, token is validated via a quick GET to `/api/auth/me`.

--- a/frontend/src/components/ChatLayout.tsx
+++ b/frontend/src/components/ChatLayout.tsx
@@ -16,6 +16,8 @@ import {
 } from "./chat-layout/chatLayoutRoomState";
 import type { Message, MessageContextResponse, OnlineUser, Room } from "../types";
 
+// Keep a bounded subscription set so unread updates stay real-time without
+// subscribing to every discovered room in large workspaces.
 const MAX_SUBSCRIPTIONS = 10;
 const INITIAL_AUTO_SUBSCRIBE_COUNT = 5;
 type UiDensity = "compact" | "comfortable";
@@ -104,6 +106,7 @@ export default function ChatLayout() {
   const tokenRef = useRef<string | null>(null);
   /** Track all active typing timeouts for cleanup on unmount */
   const typingTimeoutsRef = useRef<Set<ReturnType<typeof setTimeout>>>(new Set());
+  // Refs mirror the latest state so the WS message handler can stay registered once.
   useEffect(() => {
     selectedRoomRef.current = selectedRoom;
     subscribedRoomIdsRef.current = subscribedRoomIds;
@@ -209,6 +212,7 @@ export default function ChatLayout() {
     setRoomOpenLastReadSnapshot(
       getFreshestReadMarker(cachedReadMarker, room.last_read_at ?? null),
     );
+    // MessageList owns replaying queued WS messages; reset queue per room switch.
     setIncomingMessagesForRoom([]);
     setSidebarOpen(false);
 
@@ -230,6 +234,7 @@ export default function ChatLayout() {
       let next = [...prev, room.id];
       if (next.length > MAX_SUBSCRIPTIONS) {
         const [evict] = next;
+        // Keep local list and server subscriptions in sync when evicting LRU room.
         unsubscribe(evict);
         next = next.slice(1);
       }
@@ -280,6 +285,7 @@ export default function ChatLayout() {
   };
 
   const handleLogout = () => {
+    // Explicit unsubscribe avoids transient "ghost online users" until socket teardown.
     subscribedRoomIds.forEach((id) => unsubscribe(id));
     subscribedSentRef.current.clear();
     setSubscribedRoomIds([]);

--- a/frontend/src/components/message-list/MessageFeedContent.tsx
+++ b/frontend/src/components/message-list/MessageFeedContent.tsx
@@ -14,6 +14,7 @@ interface MessageFeedContentProps {
   messages: ChatItem[];
   density: "compact" | "comfortable";
   theme: "neon" | "amber";
+  // Marker is resolved once at room-open; render path must stay read-only.
   newMessagesAnchorId: number | null;
   highlightedMessageId: number | null;
 }
@@ -63,6 +64,7 @@ export function MessageFeedContent({
         return (
           <div key={message.id}>
             {newMessagesAnchorId === message.id && (
+              // Intentional one-time divider: lifecycle decides anchor, renderer only displays.
               <div
                 className={`flex items-center ${isComfortableDensity ? "gap-3 my-6" : "gap-2.5 my-5"}`}
               >

--- a/frontend/src/components/message-list/messageListFormatting.ts
+++ b/frontend/src/components/message-list/messageListFormatting.ts
@@ -1,5 +1,6 @@
 import type { Message } from "../../types";
 
+// Shared formatting + ordering helpers used by message lifecycle and rendering.
 export interface SystemMessage {
   id: string;
   type: "system";
@@ -10,6 +11,7 @@ export interface SystemMessage {
 export type ChatItem = Message | SystemMessage;
 
 export function normalizeToUtcIso(isoString: string): string {
+  // Backend should emit timezone-aware strings, but legacy rows/tests may not.
   const hasTimezoneSuffix = /(?:Z|[+-]\d{2}:\d{2})$/i.test(isoString);
   return hasTimezoneSuffix ? isoString : `${isoString}Z`;
 }
@@ -38,6 +40,7 @@ export function isStrictlyNewerThan(
   if (candidateTime != null && referenceTime == null) return true;
   if (candidateTime == null && referenceTime != null) return false;
 
+  // Deterministic tiebreaker when timestamps collide or are unparsable.
   return candidate.id > reference.id;
 }
 
@@ -147,6 +150,7 @@ export function capturePrependAnchor(
   );
 
   const anchorElement =
+    // First visible message keeps viewport stable when older rows are prepended.
     messageElements.find(
       (el) => el.getBoundingClientRect().bottom >= containerTop,
     ) ?? messageElements[0];

--- a/frontend/src/context/WebSocketContext.tsx
+++ b/frontend/src/context/WebSocketContext.tsx
@@ -10,6 +10,7 @@ import {
 
 export type { WebSocketMessage } from "./webSocketContextState";
 
+// Provider owns websocket lifecycle per auth token and exposes transport actions.
 export function WebSocketProvider({ children }: { children: ReactNode }) {
   const { token } = useAuth();
   const [connected, setConnected] = useState(false);
@@ -17,6 +18,7 @@ export function WebSocketProvider({ children }: { children: ReactNode }) {
   const [lastMessage, setLastMessage] = useState<WebSocketMessage | null>(null);
   const wsRef = useRef<WebSocketService | null>(null);
   const currentTokenRef = useRef<string | null>(null);
+  // Mutable callback avoids reconnecting/rebinding service on every consumer rerender.
   const messageHandlerRef = useRef<((msg: WebSocketMessage) => void) | undefined>(undefined);
 
   const registerMessageHandler = useCallback(
@@ -33,6 +35,7 @@ export function WebSocketProvider({ children }: { children: ReactNode }) {
         wsRef.current = null;
       }
       currentTokenRef.current = null;
+      // Defer state updates to keep this effect cleanup-safe in Strict Mode.
       const statusTimer = setTimeout(() => {
         setConnectionStatus("disconnected");
         setConnected(false);
@@ -60,6 +63,7 @@ export function WebSocketProvider({ children }: { children: ReactNode }) {
     ws.onMessage((data) => {
       const msg = data as WebSocketMessage;
       setLastMessage(msg);
+      // Fan out to ChatLayout-owned handler without forcing provider state shape changes.
       messageHandlerRef.current?.(msg);
     });
 

--- a/frontend/src/hooks/useChatLayoutMessageHandler.ts
+++ b/frontend/src/hooks/useChatLayoutMessageHandler.ts
@@ -8,6 +8,13 @@ import type { WebSocketMessage } from "../context/WebSocketContext";
 import { markRoomRead } from "../services/api";
 import type { Message, OnlineUser, Room } from "../types";
 
+/**
+ * Owns ChatLayout's websocket event policy.
+ * Invariants:
+ * - Never drop delivered messages for the selected room.
+ * - Keep unread counters scoped to subscribed-but-not-selected rooms.
+ * - Keep typing indicators self-healing via timeout cleanup.
+ */
 type TypingUsersByRoom = Record<
   number,
   Record<number, { username: string; timeout: ReturnType<typeof setTimeout> }>
@@ -43,6 +50,7 @@ export function useChatLayoutMessageHandler({
   useEffect(() => {
     const handleMessage = (message: WebSocketMessage) => {
       if (message.type === "error") {
+        // WS errors are transient UX hints; auto-clear prevents sticky banners.
         setWsError(message.message);
         setTimeout(() => setWsError(null), 4000);
         return;
@@ -57,9 +65,11 @@ export function useChatLayoutMessageHandler({
 
       if (message.type === "new_message" && messageRoomId != null) {
         if (messageRoomId === selectedRoomRef.current?.id) {
+          // Append into queue; MessageList consumes and clears in-order.
           setIncomingMessagesForRoom((prev) => [...prev, message.message]);
           const token = tokenRef.current;
           if (token) {
+            // Keep read marker server-authored to stay consistent across tabs/devices.
             markRoomRead(messageRoomId, token)
               .then((response) => {
                 setLastReadAtByRoomId((prev) => ({
@@ -70,6 +80,7 @@ export function useChatLayoutMessageHandler({
               .catch(() => {});
           }
         } else if (subscribedRoomIdsRef.current.includes(messageRoomId)) {
+          // Only increment unread for rooms the user explicitly tracks in the LRU set.
           setUnreadCounts((prev) => ({
             ...prev,
             [messageRoomId]: (prev[messageRoomId] ?? 0) + 1,
@@ -129,6 +140,7 @@ export function useChatLayoutMessageHandler({
           setTypingUsersByRoom((prev) => {
             const roomTyping = { ...(prev[roomId] ?? {}) };
             if (roomTyping[user.id]) {
+              // Renew timeout whenever a fresh typing event arrives for same user.
               clearTimeout(roomTyping[user.id].timeout);
               typingTimeoutsRef.current.delete(roomTyping[user.id].timeout);
             }

--- a/frontend/src/hooks/useChatLayoutShortcuts.ts
+++ b/frontend/src/hooks/useChatLayoutShortcuts.ts
@@ -1,6 +1,7 @@
 import { useEffect } from "react";
 import type { Room } from "../types";
 
+// Shared guard for global shortcuts: slash should not hijack focused form fields.
 interface UseChatLayoutShortcutsParams {
   selectedRoom: Room | null;
   onOpenCommandPalette: () => void;
@@ -43,6 +44,7 @@ export function useChatLayoutShortcuts({
         !event.altKey &&
         selectedRoom
       ) {
+        // Search is room-scoped; ignore slash when no active room exists.
         event.preventDefault();
         onOpenSearchPanel();
         return;

--- a/frontend/src/hooks/useChatLayoutSubscriptions.ts
+++ b/frontend/src/hooks/useChatLayoutSubscriptions.ts
@@ -1,5 +1,9 @@
 import { useEffect, type Dispatch, type MutableRefObject, type SetStateAction } from "react";
 
+/**
+ * Keeps local room-subscription intent and server-side WS subscriptions aligned.
+ * Reconnect invariant: every reconnect must resend current room IDs exactly once.
+ */
 interface UseChatLayoutSubscriptionsParams {
   connected: boolean;
   subscribedRoomIds: number[];
@@ -26,6 +30,7 @@ export function useChatLayoutSubscriptions({
     if (!prevConnectedRef.current && connected) {
       subscribedSentRef.current.clear();
       if (hasConnectedOnceRef.current) {
+        // Trigger Sidebar reload after reconnect so unread + room state resync from API.
         refreshTimeoutId = window.setTimeout(() => {
           setRefreshTrigger((prev) => prev + 1);
         }, 0);
@@ -50,6 +55,7 @@ export function useChatLayoutSubscriptions({
       if (subscribedSentRef.current.has(roomId)) {
         return;
       }
+      // Dedupe subscribe() calls across rerenders while keeping explicit room order local.
       subscribe(roomId);
       subscribedSentRef.current.add(roomId);
     });

--- a/frontend/src/hooks/useChatLayoutUiEffects.ts
+++ b/frontend/src/hooks/useChatLayoutUiEffects.ts
@@ -2,6 +2,7 @@ import { useEffect } from "react";
 import type { Room } from "../types";
 import { formatRoomNameForDisplay } from "../utils/roomNames";
 
+// Isolates passive UI side effects so ChatLayout orchestration stays focused on data flow.
 type UiDensity = "compact" | "comfortable";
 
 interface UseChatLayoutUiEffectsParams {
@@ -13,6 +14,7 @@ export function useChatLayoutUiEffects({
   selectedRoom,
   density,
 }: UseChatLayoutUiEffectsParams) {
+  // Density preference is user-owned UI state, so persist immediately when changed.
   useEffect(() => {
     localStorage.setItem("rostra-density", density);
   }, [density]);

--- a/frontend/src/hooks/useMessageFeedLifecycle.ts
+++ b/frontend/src/hooks/useMessageFeedLifecycle.ts
@@ -14,6 +14,13 @@ import {
   type PendingScrollAdjustment,
 } from "./useMessageFeedViewport";
 
+/**
+ * Orchestrates MessageList data lifecycle.
+ * Ownership:
+ * - Cursor pagination state (older + newer in context mode)
+ * - Initial/history/context fetch sequencing
+ * - Live message merge policy without duplicate rows
+ */
 interface UseMessageFeedLifecycleParams {
   roomId: number;
   token: string | null;
@@ -89,6 +96,7 @@ export function useMessageFeedLifecycle({
   const pendingScrollAdjustmentRef = useRef<PendingScrollAdjustment | null>(null);
   const timeoutFiredRef = useRef(false);
   const contextLiveMessagesRef = useRef<Message[]>([]);
+  // Guards async race conditions when room/mode changes mid-request.
   const paginationEpochRef = useRef(0);
 
   useEffect(() => {
@@ -98,6 +106,7 @@ export function useMessageFeedLifecycle({
   useEffect(() => {
     if (messageViewMode !== "context" || !messageContext) return;
 
+    // Entering context mode resets normal-history cursors and hydrates around anchor message.
     paginationEpochRef.current += 1;
     setError("");
     setLoading(false);
@@ -121,6 +130,7 @@ export function useMessageFeedLifecycle({
 
     const abortController = new AbortController();
     let timeoutId: number | undefined;
+    // Preserve unseen live messages captured while in context mode during mode handoff.
     const bufferedContextTail = contextLiveMessagesRef.current;
 
     if (token) {
@@ -191,6 +201,7 @@ export function useMessageFeedLifecycle({
           });
 
           const uniqueTailById = new Map<number, Message>();
+          // Keep deterministic order: existing live tail first, then buffered context tail.
           [...trueLiveTail, ...bufferedTail].forEach((message) => {
             uniqueTailById.set(message.id, message);
           });
@@ -253,6 +264,7 @@ export function useMessageFeedLifecycle({
 
     const previousScrollHeight = scrollContainer.scrollHeight;
     const previousScrollTop = scrollContainer.scrollTop;
+    // Anchor snapshot lets viewport preserve exact visible row after prepend.
     const { anchorMessageId, anchorTop } = capturePrependAnchor(scrollContainer);
     const requestEpoch = paginationEpochRef.current;
 
@@ -390,6 +402,7 @@ export function useMessageFeedLifecycle({
           return [...prev, ...toAdd];
         });
       } else {
+        // In context mode, keep live traffic separate until user returns to latest.
         setContextLiveMessages((prev) => {
           const ids = new Set(prev.map((msg) => msg.id));
           const toAdd = incomingMessages.filter((msg) => !ids.has(msg.id));

--- a/frontend/src/hooks/useMessageFeedViewport.ts
+++ b/frontend/src/hooks/useMessageFeedViewport.ts
@@ -1,6 +1,8 @@
 import { useCallback, useEffect, useLayoutEffect, useRef } from "react";
 import type { Dispatch, RefObject, SetStateAction } from "react";
 
+// Scroll policy coordinator for MessageList. It applies pending adjustments
+// produced by lifecycle events (initial load, prepend, append, context target).
 export type PendingScrollAdjustment =
   | { type: "initial" }
   | { type: "context-target"; targetMessageId: number }
@@ -65,6 +67,7 @@ export function useMessageFeedViewport({
   pendingScrollAdjustmentRef,
 }: UseMessageFeedViewportParams): UseMessageFeedViewportResult {
   const previousScrollToLatestSignalRef = useRef(scrollToLatestSignal);
+  // Suppresses jump button while smooth scroll animation is in-flight.
   const jumpVisibilitySuppressedRef = useRef(false);
 
   const isNearBottom = useCallback((container: HTMLDivElement): boolean => {
@@ -86,6 +89,7 @@ export function useMessageFeedViewport({
     }
 
     if (messageViewMode === "context") {
+      // In context mode, the button is both "jump to latest" and "exit context".
       if (newerCursor !== null) {
         setShowJumpToLatest(true);
         return;
@@ -302,6 +306,7 @@ export function useMessageFeedViewport({
       },
       {
         root: scrollContainerRef.current,
+        // Smaller prefetch window at bottom keeps context-mode newer paging predictable.
         rootMargin: "100px",
         threshold: 0,
       }

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -9,6 +9,10 @@ import type {
   MessageContextResponse,
 } from "../types";
 
+// Central API client used by all frontend features.
+// Contract invariants:
+// - All HTTP calls flow through apiCall() for consistent timeout/retry/error handling.
+// - 401 always triggers the registered unauthorized handler before surfacing error.
 const BASE_URL = import.meta.env.VITE_API_URL || "http://localhost:8000";
 
 const API_URL = `${BASE_URL}/api`;
@@ -138,6 +142,7 @@ async function apiCall<T>(endpoint: string, options?: RequestInit): Promise<T> {
 
         // Wait before retry
         if (attempt < RETRY_CONFIG.maxRetries) {
+          // Backoff keeps cold-start bursts from hammering the backend wake-up path.
           await new Promise(resolve => setTimeout(resolve, getDelay(attempt)));
         }
       } else {

--- a/frontend/src/services/websocket.ts
+++ b/frontend/src/services/websocket.ts
@@ -1,5 +1,6 @@
 import { logDebug, logError } from "../utils/logger";
 
+// Thin transport wrapper; ChatLayout owns room-subscription policy.
 const API_URL = import.meta.env.VITE_API_URL || "http://localhost:8000";
 const WS_BASE_URL =
   resolveWebSocketBaseUrl(API_URL, import.meta.env.VITE_WS_URL) ||
@@ -153,6 +154,7 @@ export class WebSocketService {
           // Attempt to reconnect for abnormal closures
           this.attemptReconnect();
         } else {
+          // Expected disconnect path (logout/token rotate/manual close).
           this.onStatusChangeCallback?.("disconnected");
         }
       };
@@ -172,6 +174,7 @@ export class WebSocketService {
   }
 
   disconnect() {
+    // Disable reconnect before closing so manual teardown does not loop.
     this.shouldReconnect = false;
     clearTimeout(this.connectionTimeout);
     


### PR DESCRIPTION
## Summary

Adds a comments/documentation-only readability pass across frontend orchestration, feed lifecycle, and transport files.

- Added high-signal ownership/invariant comments in ChatLayout + extracted chat hooks.
- Added lifecycle/scroll/pagination rationale comments in message feed hooks/helpers.
- Added retry/reconnect/dispatch semantics comments in API + WebSocket service/context.
- Added reusable frontend commenting convention section to `docs/PATTERNS.md`.

No runtime behavior, API/WS contracts, styling, or dependencies were changed.

## Linked Issue

- Closes #26
- Parent Spec: #14

## Scope

**In scope:**
- Comments/documentation-only pass for targeted frontend hotspot files.
- Clarify state ownership, side-effect intent, event/data flow, and non-obvious guardrails.
- `docs/PATTERNS.md` update for reusable comment convention.

**Out of scope:**
- Feature behavior changes.
- API/WebSocket contract changes.
- Dependency or migration changes.
- UX/styling changes.

## Acceptance Criteria Check

- [x] Acceptance criteria from Task issue are fully met

## Verification

```bash
make frontend-verify
```

Result: pass
- Type check: pass (`npx tsc --noEmit`)
- Lint: pass (`npx eslint src/`)
- Build: pass (`npm run build`)
- Tests: pass (`npm test`, 19 files / 152 tests)

## Docs and Decisions

- [x] Docs updated as needed
- [x] ADR created/linked if decision has lasting architecture/security/perf impact

Notes:
- Updated `docs/PATTERNS.md` with a reusable frontend commenting pattern.
- No ADR needed (documentation-only, no architecture/security/performance decision change).

## Risks / Rollback

- Risk level: Low (comments/docs only)
- Rollback plan: Revert commit `8ff3172`
