### PR TITLE
Feat: Phase 3.5 message reactions with menu-based UX

### DIFF
--- a/backend/TESTPLAN.md
+++ b/backend/TESTPLAN.md
@@ -625,6 +625,58 @@ If refresh-token auth is added later, define this section in a dedicated Spec an
 
 ---
 
+### POST /api/messages/:message_id/reactions
+### DELETE /api/messages/:message_id/reactions/:emoji
+
+**Happy Path:**
+- `test_add_reaction_member_succeeds_and_returns_summary`
+  - Room member adds allowlisted emoji reaction
+  - Endpoint returns 200 with updated message reaction summary entries
+  - Summary includes `emoji`, `count`, `reacted_by_me`
+
+- `test_remove_reaction_owner_succeeds_and_returns_summary`
+  - Caller removes their own existing reaction
+  - Endpoint returns 200 and updated summary
+
+- `test_reaction_endpoints_emit_ws_events_with_expected_payload`
+  - Add emits `reaction_added`; remove emits `reaction_removed`
+  - Payload includes `room_id`, `message_id`, `emoji`, `user_id`, `count`
+
+**Authorization / Security Cases:**
+- `test_add_reaction_not_room_member_returns_403`
+  - Non-member cannot react to room messages
+
+- `test_remove_reaction_only_owns_row`
+  - Caller cannot remove another user's reaction row
+  - Endpoint rejects with not-found/forbidden semantics for non-owned reaction
+
+**Behavioral Cases:**
+- `test_duplicate_same_emoji_reaction_same_user_does_not_create_second_row`
+  - Duplicate same-emoji reaction from same user is prevented by uniqueness
+  - Endpoint behavior matches explicit add/remove toggle contract
+
+- `test_reaction_summary_sorted_by_count_then_allowlist_order`
+  - Summary ordering is count desc, ties resolved by allowlist order
+
+- `test_deleted_message_cannot_be_reacted_to`
+  - Add/remove on soft-deleted message is rejected
+  - Deleted-message payloads show no reactions
+
+- `test_delete_message_removes_stored_reactions`
+  - Reactions exist before soft delete
+  - After delete, stored reactions for that message are removed
+
+**Validation Cases:**
+- `test_add_reaction_non_allowlisted_emoji_returns_422`
+  - Emoji outside allowlist is rejected
+
+**Rate Limit Cases:**
+- `test_reaction_rate_limit_40_per_minute`
+  - Perform 41 reaction mutations within one minute from same client
+  - First 40 succeed, request 41 returns 429
+
+---
+
 ### GET /api/rooms/:id/messages/search
 
 **Happy Path:**

--- a/backend/alembic/env.py
+++ b/backend/alembic/env.py
@@ -9,7 +9,7 @@ from app.core.config import settings
 from app.core.database import Base
 
 # Import all models so Alembic can discover them
-from app.models import message, room, user, user_room  # noqa: F401
+from app.models import message, message_reaction, room, user, user_room  # noqa: F401
 
 config = context.config
 

--- a/backend/alembic/versions/c2d3e4f5a6b7_add_message_reactions_table.py
+++ b/backend/alembic/versions/c2d3e4f5a6b7_add_message_reactions_table.py
@@ -1,0 +1,75 @@
+"""add message_reactions table for message reaction feature
+
+Revision ID: c2d3e4f5a6b7
+Revises: b1e2f3a4c5d6
+Create Date: 2026-02-24 11:30:00.000000
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "c2d3e4f5a6b7"
+down_revision: str | Sequence[str] | None = "b1e2f3a4c5d6"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "message_reactions",
+        sa.Column("id", sa.BigInteger(), nullable=False),
+        sa.Column("message_id", sa.BigInteger(), nullable=False),
+        sa.Column("user_id", sa.BigInteger(), nullable=False),
+        sa.Column("emoji", sa.String(length=8), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.ForeignKeyConstraint(
+            ["message_id"],
+            ["rostra.messages.id"],
+            ondelete="CASCADE",
+        ),
+        sa.ForeignKeyConstraint(
+            ["user_id"],
+            ["rostra.users.id"],
+            ondelete="CASCADE",
+        ),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint(
+            "message_id",
+            "user_id",
+            "emoji",
+            name="uq_message_reactions_message_user_emoji",
+        ),
+        schema="rostra",
+    )
+    op.create_index(
+        "ix_message_reactions_message_id",
+        "message_reactions",
+        ["message_id"],
+        unique=False,
+        schema="rostra",
+    )
+    op.create_index(
+        "ix_message_reactions_user_id",
+        "message_reactions",
+        ["user_id"],
+        unique=False,
+        schema="rostra",
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "ix_message_reactions_user_id",
+        table_name="message_reactions",
+        schema="rostra",
+    )
+    op.drop_index(
+        "ix_message_reactions_message_id",
+        table_name="message_reactions",
+        schema="rostra",
+    )
+    op.drop_table("message_reactions", schema="rostra")

--- a/backend/app/api/messages.py
+++ b/backend/app/api/messages.py
@@ -9,10 +9,15 @@ from app.core.rate_limit import limiter
 from app.crud import message as message_crud
 from app.crud import room as room_crud
 from app.crud import user_room as user_room_crud
+from app.models.message import Message as MessageModel
 from app.models.user import User
 from app.schemas.message import (
+    REACTION_EMOJI_ALLOWLIST,
     MessageContextResponse,
     MessageCreate,
+    MessageReactionAdd,
+    MessageReactionSummary,
+    MessageReactionUpdateResponse,
     MessageResponse,
     MessageUpdate,
     PaginatedMessages,
@@ -24,9 +29,62 @@ from app.websocket.schemas import (
     WSEditedMessage,
     WSMessageDeleted,
     WSMessageEdited,
+    WSMessageReactionAdded,
+    WSMessageReactionRemoved,
+    WSReactionMessage,
 )
 
 router = APIRouter()
+
+
+def _validate_reaction_emoji(emoji: str) -> str:
+    if emoji not in REACTION_EMOJI_ALLOWLIST:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail=(
+                f"Emoji must be one of: {', '.join(REACTION_EMOJI_ALLOWLIST)}"
+            ),
+        )
+    return emoji
+
+
+async def _get_reaction_summary_map(
+    db: AsyncSession,
+    messages: list[MessageModel],
+    current_user_id: int,
+) -> dict[int, list[MessageReactionSummary]]:
+    message_ids = [int(msg.id) for msg in messages]
+    return await message_crud.get_reaction_summaries_for_message_ids(
+        db,
+        message_ids,
+        current_user_id,
+    )
+
+
+def _to_message_response(
+    msg: MessageModel,
+    reaction_summary_map: dict[int, list[MessageReactionSummary]],
+) -> MessageResponse:
+    msg_id: int = msg.id  # type: ignore[assignment]
+    msg_room_id: int = msg.room_id  # type: ignore[assignment]
+    msg_user_id: int = msg.user_id  # type: ignore[assignment]
+    msg_content: str = msg.content  # type: ignore[assignment]
+    msg_created_at: datetime = msg.created_at  # type: ignore[assignment]
+    msg_edited_at: datetime | None = msg.edited_at  # type: ignore[assignment]
+    msg_deleted_at: datetime | None = msg.deleted_at  # type: ignore[assignment]
+    msg_username: str = msg.user.username  # type: ignore[union-attr]
+
+    return MessageResponse(
+        id=msg_id,
+        room_id=msg_room_id,
+        user_id=msg_user_id,
+        username=msg_username,
+        content=msg_content,
+        created_at=msg_created_at,
+        edited_at=msg_edited_at,
+        deleted_at=msg_deleted_at,
+        reactions=reaction_summary_map.get(msg_id, []),
+    )
 
 
 @router.get("/rooms/{room_id}/messages/search", response_model=PaginatedMessages)
@@ -98,30 +156,10 @@ async def search_room_messages(
     if has_more:
         messages = messages[:limit]
 
-    # Build response — same pattern as get_room_messages
-    response_messages = []
-    for msg in messages:
-        msg_id: int = msg.id  # type: ignore[assignment]
-        msg_room_id: int = msg.room_id  # type: ignore[assignment]
-        msg_user_id: int = msg.user_id  # type: ignore[assignment]
-        msg_content: str = msg.content  # type: ignore[assignment]
-        msg_created_at: datetime = msg.created_at  # type: ignore[assignment]
-        msg_edited_at: datetime | None = msg.edited_at  # type: ignore[assignment]
-        msg_deleted_at: datetime | None = msg.deleted_at  # type: ignore[assignment]
-        msg_username: str = msg.user.username  # type: ignore[union-attr]
-
-        response_messages.append(
-            MessageResponse(
-                id=msg_id,
-                room_id=msg_room_id,
-                user_id=msg_user_id,
-                username=msg_username,
-                content=msg_content,
-                created_at=msg_created_at,
-                edited_at=msg_edited_at,
-                deleted_at=msg_deleted_at,
-            )
-        )
+    reaction_summary_map = await _get_reaction_summary_map(db, messages, current_user.id)
+    response_messages = [
+        _to_message_response(msg, reaction_summary_map) for msg in messages
+    ]
 
     # Create next_cursor if there are more results
     next_cursor = None
@@ -199,33 +237,10 @@ async def get_room_messages(
         # Trim to the requested limit
         messages = messages[:limit]
 
-    # Build response messages
-    # We need to manually construct MessageResponse to include username from the relationship
-    # Cannot use model_validate(msg) directly because username isn't a Message column
-    response_messages = []
-    for msg in messages:
-        # Access attributes and assign to variables to help mypy infer correct types
-        msg_id: int = msg.id  # type: ignore[assignment]
-        msg_room_id: int = msg.room_id  # type: ignore[assignment]
-        msg_user_id: int = msg.user_id  # type: ignore[assignment]
-        msg_content: str = msg.content  # type: ignore[assignment]
-        msg_created_at: datetime = msg.created_at  # type: ignore[assignment]
-        msg_edited_at: datetime | None = msg.edited_at  # type: ignore[assignment]
-        msg_deleted_at: datetime | None = msg.deleted_at  # type: ignore[assignment]
-        msg_username: str = msg.user.username  # type: ignore[union-attr]
-
-        response_messages.append(
-            MessageResponse(
-                id=msg_id,
-                room_id=msg_room_id,
-                user_id=msg_user_id,
-                username=msg_username,
-                content=msg_content,
-                created_at=msg_created_at,
-                edited_at=msg_edited_at,
-                deleted_at=msg_deleted_at,
-            )
-        )
+    reaction_summary_map = await _get_reaction_summary_map(db, messages, current_user.id)
+    response_messages = [
+        _to_message_response(msg, reaction_summary_map) for msg in messages
+    ]
 
     # Create next_cursor if there are more messages
     # The cursor points to the last message we're returning, so the next
@@ -282,29 +297,10 @@ async def get_room_messages_newer(
     if has_more:
         messages = messages[:limit]
 
-    response_messages = []
-    for msg in messages:
-        msg_id: int = msg.id  # type: ignore[assignment]
-        msg_room_id: int = msg.room_id  # type: ignore[assignment]
-        msg_user_id: int = msg.user_id  # type: ignore[assignment]
-        msg_content: str = msg.content  # type: ignore[assignment]
-        msg_created_at: datetime = msg.created_at  # type: ignore[assignment]
-        msg_edited_at: datetime | None = msg.edited_at  # type: ignore[assignment]
-        msg_deleted_at: datetime | None = msg.deleted_at  # type: ignore[assignment]
-        msg_username: str = msg.user.username  # type: ignore[union-attr]
-
-        response_messages.append(
-            MessageResponse(
-                id=msg_id,
-                room_id=msg_room_id,
-                user_id=msg_user_id,
-                username=msg_username,
-                content=msg_content,
-                created_at=msg_created_at,
-                edited_at=msg_edited_at,
-                deleted_at=msg_deleted_at,
-            )
-        )
+    reaction_summary_map = await _get_reaction_summary_map(db, messages, current_user.id)
+    response_messages = [
+        _to_message_response(msg, reaction_summary_map) for msg in messages
+    ]
 
     next_cursor = None
     if has_more and messages:
@@ -375,29 +371,12 @@ async def get_room_message_context(
 
     window_messages = [*older_asc, target, *newer_asc]
 
-    response_messages = []
-    for msg in window_messages:
-        msg_id: int = msg.id  # type: ignore[assignment]
-        msg_room_id: int = msg.room_id  # type: ignore[assignment]
-        msg_user_id: int = msg.user_id  # type: ignore[assignment]
-        msg_content: str = msg.content  # type: ignore[assignment]
-        msg_created_at: datetime = msg.created_at  # type: ignore[assignment]
-        msg_edited_at: datetime | None = msg.edited_at  # type: ignore[assignment]
-        msg_deleted_at: datetime | None = msg.deleted_at  # type: ignore[assignment]
-        msg_username: str = msg.user.username  # type: ignore[union-attr]
-
-        response_messages.append(
-            MessageResponse(
-                id=msg_id,
-                room_id=msg_room_id,
-                user_id=msg_user_id,
-                username=msg_username,
-                content=msg_content,
-                created_at=msg_created_at,
-                edited_at=msg_edited_at,
-                deleted_at=msg_deleted_at,
-            )
-        )
+    reaction_summary_map = await _get_reaction_summary_map(
+        db, window_messages, current_user.id
+    )
+    response_messages = [
+        _to_message_response(msg, reaction_summary_map) for msg in window_messages
+    ]
 
     older_cursor = None
     if has_more_older and window_messages:
@@ -540,6 +519,12 @@ async def edit_message(
         payload.model_dump(mode="json"),
     )
 
+    reaction_summary_map = await _get_reaction_summary_map(
+        db,
+        [updated_message],
+        current_user_id,
+    )
+
     return MessageResponse(
         id=updated_message_id,
         room_id=updated_room_id,
@@ -549,6 +534,7 @@ async def edit_message(
         created_at=updated_created_at,
         edited_at=updated_edited_at,
         deleted_at=updated_deleted_at,
+        reactions=reaction_summary_map.get(updated_message_id, []),
     )
 
 
@@ -614,3 +600,164 @@ async def delete_message(
         )
 
     return Response(status_code=status.HTTP_204_NO_CONTENT)
+
+
+@router.post(
+    "/messages/{message_id}/reactions",
+    response_model=MessageReactionUpdateResponse,
+)
+@limiter.limit("40/minute")
+async def add_message_reaction(
+    request: Request,
+    message_id: int,
+    reaction: MessageReactionAdd,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> MessageReactionUpdateResponse:
+    """Add a caller-owned emoji reaction when caller is a room member."""
+    db_message = await message_crud.get_message_by_id(db, message_id)
+    if not db_message:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Message not found",
+        )
+
+    message_room_id: int = db_message.room_id  # type: ignore[assignment]
+    message_deleted_at: datetime | None = db_message.deleted_at  # type: ignore[assignment]
+    current_user_id: int = current_user.id
+
+    membership = await user_room_crud.get_user_room(db, current_user_id, message_room_id)
+    if not membership:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Not a member of this room",
+        )
+
+    if message_deleted_at is not None:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="Cannot react to a deleted message",
+        )
+
+    created = await message_crud.add_message_reaction(
+        db,
+        message_id=message_id,
+        user_id=current_user_id,
+        emoji=reaction.emoji,
+    )
+
+    reaction_count = await message_crud.get_reaction_count_for_emoji(
+        db,
+        message_id=message_id,
+        emoji=reaction.emoji,
+    )
+    summary_map = await message_crud.get_reaction_summaries_for_message_ids(
+        db,
+        [message_id],
+        current_user_id,
+    )
+
+    if created:
+        payload = WSMessageReactionAdded(
+            type="reaction_added",
+            reaction=WSReactionMessage(
+                room_id=message_room_id,
+                message_id=message_id,
+                emoji=reaction.emoji,
+                user_id=current_user_id,
+                count=reaction_count,
+            ),
+        )
+        await manager.broadcast_to_room(
+            message_room_id,
+            payload.model_dump(mode="json"),
+        )
+
+    return MessageReactionUpdateResponse(
+        message_id=message_id,
+        room_id=message_room_id,
+        reactions=summary_map.get(message_id, []),
+    )
+
+
+@router.delete(
+    "/messages/{message_id}/reactions/{emoji}",
+    response_model=MessageReactionUpdateResponse,
+)
+@limiter.limit("40/minute")
+async def remove_message_reaction(
+    request: Request,
+    message_id: int,
+    emoji: str,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> MessageReactionUpdateResponse:
+    """Remove caller-owned reaction row for an emoji."""
+    validated_emoji = _validate_reaction_emoji(emoji)
+    db_message = await message_crud.get_message_by_id(db, message_id)
+    if not db_message:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Message not found",
+        )
+
+    message_room_id: int = db_message.room_id  # type: ignore[assignment]
+    message_deleted_at: datetime | None = db_message.deleted_at  # type: ignore[assignment]
+    current_user_id: int = current_user.id
+
+    membership = await user_room_crud.get_user_room(db, current_user_id, message_room_id)
+    if not membership:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Not a member of this room",
+        )
+
+    if message_deleted_at is not None:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="Cannot react to a deleted message",
+        )
+
+    removed = await message_crud.remove_message_reaction(
+        db,
+        message_id=message_id,
+        user_id=current_user_id,
+        emoji=validated_emoji,
+    )
+    if not removed:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Reaction not found",
+        )
+
+    reaction_count = await message_crud.get_reaction_count_for_emoji(
+        db,
+        message_id=message_id,
+        emoji=validated_emoji,
+    )
+    summary_map = await message_crud.get_reaction_summaries_for_message_ids(
+        db,
+        [message_id],
+        current_user_id,
+    )
+
+    payload = WSMessageReactionRemoved(
+        type="reaction_removed",
+        reaction=WSReactionMessage(
+            room_id=message_room_id,
+            message_id=message_id,
+            emoji=validated_emoji,
+            user_id=current_user_id,
+            count=reaction_count,
+        ),
+    )
+    await manager.broadcast_to_room(
+        message_room_id,
+        payload.model_dump(mode="json"),
+    )
+
+    return MessageReactionUpdateResponse(
+        message_id=message_id,
+        room_id=message_room_id,
+        reactions=summary_map.get(message_id, []),
+    )

--- a/backend/app/crud/message.py
+++ b/backend/app/crud/message.py
@@ -1,11 +1,17 @@
+from collections import defaultdict
 from datetime import UTC, datetime
 
-from sqlalchemy import and_, func, or_, select
+from sqlalchemy import and_, case, delete, func, or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
 from app.models.message import Message
-from app.schemas.message import MessageCreate
+from app.models.message_reaction import MessageReaction
+from app.schemas.message import (
+    REACTION_EMOJI_ALLOWLIST,
+    MessageCreate,
+    MessageReactionSummary,
+)
 
 
 async def get_messages_by_room(
@@ -123,6 +129,8 @@ async def soft_delete_message(db: AsyncSession, message: Message) -> Message:
     """Soft-delete a message by scrubbing content and setting deleted_at."""
     message.content = ""
     message.deleted_at = datetime.now(UTC)
+    # Deleting reactions on soft-delete enforces non-reactable tombstones.
+    await db.execute(delete(MessageReaction).where(MessageReaction.message_id == message.id))
     await db.commit()
     await db.refresh(message)
     return message
@@ -238,3 +246,116 @@ async def get_messages_newer_than(
 
     result = await db.execute(stmt)
     return list(result.scalars().all())
+
+
+async def get_reaction_summaries_for_message_ids(
+    db: AsyncSession,
+    message_ids: list[int],
+    current_user_id: int,
+) -> dict[int, list[MessageReactionSummary]]:
+    """Return aggregated reaction summaries keyed by message id."""
+    if not message_ids:
+        return {}
+
+    stmt = (
+        select(
+            MessageReaction.message_id,
+            MessageReaction.emoji,
+            func.count(MessageReaction.id).label("count"),
+            func.max(
+                case((MessageReaction.user_id == current_user_id, 1), else_=0)
+            ).label("reacted_by_me"),
+        )
+        .where(MessageReaction.message_id.in_(message_ids))
+        .group_by(MessageReaction.message_id, MessageReaction.emoji)
+    )
+    result = await db.execute(stmt)
+
+    emoji_order = {
+        emoji: index for index, emoji in enumerate(REACTION_EMOJI_ALLOWLIST)
+    }
+    summaries_by_message: dict[int, list[MessageReactionSummary]] = defaultdict(list)
+    for message_id, emoji, count, reacted_by_me in result.all():
+        emoji_value = str(emoji)
+        if emoji_value not in emoji_order:
+            continue
+        summaries_by_message[int(message_id)].append(
+            MessageReactionSummary(
+                emoji=emoji_value,  # type: ignore[arg-type]
+                count=int(count),
+                reacted_by_me=bool(reacted_by_me),
+            )
+        )
+
+    for message_summary in summaries_by_message.values():
+        message_summary.sort(
+            key=lambda summary: (
+                -summary.count,
+                emoji_order.get(summary.emoji, len(emoji_order)),
+            )
+        )
+
+    return dict(summaries_by_message)
+
+
+async def add_message_reaction(
+    db: AsyncSession,
+    message_id: int,
+    user_id: int,
+    emoji: str,
+) -> bool:
+    """Add reaction row if missing. Returns True when a new row was created."""
+    existing_stmt = select(MessageReaction).where(
+        MessageReaction.message_id == message_id,
+        MessageReaction.user_id == user_id,
+        MessageReaction.emoji == emoji,
+    )
+    existing = await db.execute(existing_stmt)
+    if existing.scalar_one_or_none():
+        return False
+
+    db.add(
+        MessageReaction(
+            message_id=message_id,
+            user_id=user_id,
+            emoji=emoji,
+        )
+    )
+    await db.commit()
+    return True
+
+
+async def remove_message_reaction(
+    db: AsyncSession,
+    message_id: int,
+    user_id: int,
+    emoji: str,
+) -> bool:
+    """Remove caller-owned reaction row. Returns True when deleted."""
+    stmt = select(MessageReaction).where(
+        MessageReaction.message_id == message_id,
+        MessageReaction.user_id == user_id,
+        MessageReaction.emoji == emoji,
+    )
+    result = await db.execute(stmt)
+    reaction = result.scalar_one_or_none()
+    if reaction is None:
+        return False
+
+    await db.delete(reaction)
+    await db.commit()
+    return True
+
+
+async def get_reaction_count_for_emoji(
+    db: AsyncSession,
+    message_id: int,
+    emoji: str,
+) -> int:
+    """Get current aggregate count for one emoji on a message."""
+    stmt = select(func.count(MessageReaction.id)).where(
+        MessageReaction.message_id == message_id,
+        MessageReaction.emoji == emoji,
+    )
+    result = await db.execute(stmt)
+    return int(result.scalar_one())

--- a/backend/app/models/message.py
+++ b/backend/app/models/message.py
@@ -41,6 +41,11 @@ class Message(Base):
     # Relationships
     user = relationship("User", back_populates="messages")
     room = relationship("Room", back_populates="messages")
+    reactions = relationship(
+        "MessageReaction",
+        back_populates="message",
+        cascade="all, delete-orphan",
+    )
 
     __table_args__ = (
         # Composite index for cursor-based pagination (room_id, created_at DESC, id DESC)

--- a/backend/app/models/message_reaction.py
+++ b/backend/app/models/message_reaction.py
@@ -1,0 +1,42 @@
+from datetime import UTC, datetime
+
+from sqlalchemy import BigInteger, DateTime, ForeignKey, Index, String, UniqueConstraint
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from app.core.database import Base
+
+
+class MessageReaction(Base):
+    __tablename__ = "message_reactions"
+
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True)
+    message_id: Mapped[int] = mapped_column(
+        BigInteger,
+        ForeignKey("messages.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    user_id: Mapped[int] = mapped_column(
+        BigInteger,
+        ForeignKey("users.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    emoji: Mapped[str] = mapped_column(String(8), nullable=False)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        default=lambda: datetime.now(UTC),
+        nullable=False,
+    )
+
+    message = relationship("Message", back_populates="reactions")
+    user = relationship("User", back_populates="message_reactions")
+
+    __table_args__ = (
+        UniqueConstraint(
+            "message_id",
+            "user_id",
+            "emoji",
+            name="uq_message_reactions_message_user_emoji",
+        ),
+        Index("ix_message_reactions_message_id", "message_id"),
+        Index("ix_message_reactions_user_id", "user_id"),
+    )

--- a/backend/app/models/user.py
+++ b/backend/app/models/user.py
@@ -22,6 +22,11 @@ class User(Base):
 
     # Relationships
     messages = relationship("Message", back_populates="user")
+    message_reactions = relationship(
+        "MessageReaction",
+        back_populates="user",
+        cascade="all, delete-orphan",
+    )
     rooms = relationship("Room", back_populates="creator")
     user_rooms = relationship(
         "UserRoom", back_populates="user", cascade="all, delete-orphan"

--- a/backend/app/schemas/message.py
+++ b/backend/app/schemas/message.py
@@ -1,6 +1,10 @@
 from datetime import datetime
+from typing import Literal
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+REACTION_EMOJI_ALLOWLIST = ("👍", "👎", "❤️", "😂", "🔥", "👀", "🎉")
+ReactionEmoji = Literal["👍", "👎", "❤️", "😂", "🔥", "👀", "🎉"]
 
 
 class MessageCreate(BaseModel):
@@ -32,6 +36,20 @@ class MessageUpdate(BaseModel):
         return v
 
 
+class MessageReactionAdd(BaseModel):
+    """Schema for adding an emoji reaction to a message."""
+
+    emoji: ReactionEmoji
+
+
+class MessageReactionSummary(BaseModel):
+    """Aggregated reaction state for a single emoji on a message."""
+
+    emoji: ReactionEmoji
+    count: int
+    reacted_by_me: bool
+
+
 class MessageResponse(BaseModel):
     """Schema for message in responses"""
 
@@ -45,6 +63,7 @@ class MessageResponse(BaseModel):
     created_at: datetime
     edited_at: datetime | None = None
     deleted_at: datetime | None = None
+    reactions: list[MessageReactionSummary] = Field(default_factory=list)
 
 
 class PaginatedMessages(BaseModel):
@@ -61,3 +80,11 @@ class MessageContextResponse(BaseModel):
     target_message_id: int
     older_cursor: str | None = None
     newer_cursor: str | None = None
+
+
+class MessageReactionUpdateResponse(BaseModel):
+    """Schema returned by reaction mutation endpoints."""
+
+    message_id: int
+    room_id: int
+    reactions: list[MessageReactionSummary]

--- a/backend/app/websocket/schemas.py
+++ b/backend/app/websocket/schemas.py
@@ -108,6 +108,30 @@ class WSMessageEdited(BaseModel):
     message: WSEditedMessage
 
 
+class WSReactionMessage(BaseModel):
+    """Reaction delta payload for realtime reaction updates."""
+
+    room_id: int
+    message_id: int
+    emoji: str
+    user_id: int
+    count: int
+
+
+class WSMessageReactionAdded(BaseModel):
+    """Server broadcasts reaction add event."""
+
+    type: Literal["reaction_added"]
+    reaction: WSReactionMessage
+
+
+class WSMessageReactionRemoved(BaseModel):
+    """Server broadcasts reaction remove event."""
+
+    type: Literal["reaction_removed"]
+    reaction: WSReactionMessage
+
+
 class WSUserJoined(BaseModel):
     """Server notifies that user joined room"""
 

--- a/backend/tests/test_messages.py
+++ b/backend/tests/test_messages.py
@@ -1531,6 +1531,318 @@ async def test_delete_message_rate_limit_20_per_minute(
 
 
 # ============================================================================
+# POST /api/messages/:message_id/reactions
+# DELETE /api/messages/:message_id/reactions/:emoji
+# ============================================================================
+
+
+async def test_add_reaction_member_succeeds_and_returns_summary(
+    client: AsyncClient, create_user, create_room, create_message
+):
+    """Room member can add allowlisted reaction and receive updated summary."""
+    user_data = await create_user(email="reactmember@test.com", username="reactmember")
+    token = user_data["access_token"]
+    room = await create_room(token, "Reaction Room")
+    room_id = room["id"]
+    message = await create_message(token, room_id, "React to this")
+
+    add_response = await client.post(
+        f"/api/messages/{message['id']}/reactions",
+        json={"emoji": "👍"},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert add_response.status_code == 200
+    add_payload = add_response.json()
+
+    assert add_payload["message_id"] == message["id"]
+    assert add_payload["room_id"] == room_id
+    assert add_payload["reactions"] == [
+        {"emoji": "👍", "count": 1, "reacted_by_me": True}
+    ]
+
+    history_response = await client.get(
+        f"/api/rooms/{room_id}/messages",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert history_response.status_code == 200
+    history_message = history_response.json()["messages"][0]
+    assert history_message["reactions"] == [
+        {"emoji": "👍", "count": 1, "reacted_by_me": True}
+    ]
+
+
+async def test_add_reaction_non_allowlisted_emoji_returns_422(
+    client: AsyncClient, create_user, create_room, create_message
+):
+    """Emoji outside the allowlist is rejected."""
+    user_data = await create_user(email="reactbademoji@test.com", username="reactbademoji")
+    token = user_data["access_token"]
+    room = await create_room(token, "Bad Emoji Reaction Room")
+    room_id = room["id"]
+    message = await create_message(token, room_id, "No custom emoji in v1")
+
+    response = await client.post(
+        f"/api/messages/{message['id']}/reactions",
+        json={"emoji": "😎"},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert response.status_code == 422
+
+
+async def test_add_reaction_not_room_member_returns_403(
+    client: AsyncClient, create_user, create_room, create_message
+):
+    """Users outside room membership cannot react."""
+    owner = await create_user(email="reactowner@test.com", username="reactowner")
+    owner_token = owner["access_token"]
+    outsider = await create_user(email="reactoutsider@test.com", username="reactoutsider")
+    outsider_token = outsider["access_token"]
+
+    room = await create_room(owner_token, "Reaction Membership Room")
+    room_id = room["id"]
+    message = await create_message(owner_token, room_id, "Members only reactions")
+
+    response = await client.post(
+        f"/api/messages/{message['id']}/reactions",
+        json={"emoji": "🔥"},
+        headers={"Authorization": f"Bearer {outsider_token}"},
+    )
+    assert response.status_code == 403
+
+
+async def test_remove_reaction_only_owns_row(
+    client: AsyncClient, create_user, create_room, create_message
+):
+    """Caller can only remove reactions they own."""
+    owner = await create_user(email="reactowner2@test.com", username="reactowner2")
+    owner_token = owner["access_token"]
+    member = await create_user(email="reactmember2@test.com", username="reactmember2")
+    member_token = member["access_token"]
+
+    room = await create_room(owner_token, "Reaction Ownership Room")
+    room_id = room["id"]
+    join_response = await client.post(
+        f"/api/rooms/{room_id}/join",
+        headers={"Authorization": f"Bearer {member_token}"},
+    )
+    assert join_response.status_code == 200
+
+    message = await create_message(owner_token, room_id, "Owner reaction row")
+    add_response = await client.post(
+        f"/api/messages/{message['id']}/reactions",
+        json={"emoji": "❤️"},
+        headers={"Authorization": f"Bearer {owner_token}"},
+    )
+    assert add_response.status_code == 200
+
+    remove_response = await client.delete(
+        f"/api/messages/{message['id']}/reactions/%E2%9D%A4%EF%B8%8F",
+        headers={"Authorization": f"Bearer {member_token}"},
+    )
+    assert remove_response.status_code == 404
+
+
+async def test_duplicate_same_emoji_reaction_same_user_does_not_create_second_row(
+    client: AsyncClient, create_user, create_room, create_message
+):
+    """Duplicate same-emoji reactions by same user keep aggregate count at one."""
+    user_data = await create_user(email="reactdup@test.com", username="reactdup")
+    token = user_data["access_token"]
+    room = await create_room(token, "Reaction Duplicate Room")
+    room_id = room["id"]
+    message = await create_message(token, room_id, "Duplicate reaction target")
+
+    first_add = await client.post(
+        f"/api/messages/{message['id']}/reactions",
+        json={"emoji": "👀"},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    second_add = await client.post(
+        f"/api/messages/{message['id']}/reactions",
+        json={"emoji": "👀"},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+
+    assert first_add.status_code == 200
+    assert second_add.status_code == 200
+    assert second_add.json()["reactions"] == [
+        {"emoji": "👀", "count": 1, "reacted_by_me": True}
+    ]
+
+
+async def test_reaction_summary_sorted_by_count_then_allowlist_order(
+    client: AsyncClient, create_user, create_room, create_message
+):
+    """Summary order is count desc with allowlist-order tie break."""
+    owner = await create_user(email="reactsortowner@test.com", username="reactsortowner")
+    owner_token = owner["access_token"]
+    member_a = await create_user(email="reactsorta@test.com", username="reactsorta")
+    member_a_token = member_a["access_token"]
+    member_b = await create_user(email="reactsortb@test.com", username="reactsortb")
+    member_b_token = member_b["access_token"]
+
+    room = await create_room(owner_token, "Reaction Sort Room")
+    room_id = room["id"]
+    for member_token in (member_a_token, member_b_token):
+        join_response = await client.post(
+            f"/api/rooms/{room_id}/join",
+            headers={"Authorization": f"Bearer {member_token}"},
+        )
+        assert join_response.status_code == 200
+
+    message = await create_message(owner_token, room_id, "Sort reactions")
+
+    for token, emojis in (
+        (owner_token, ("👍", "❤️", "😂")),
+        (member_a_token, ("👍", "❤️", "😂")),
+        (member_b_token, ("👍",)),
+    ):
+        for emoji in emojis:
+            add_response = await client.post(
+                f"/api/messages/{message['id']}/reactions",
+                json={"emoji": emoji},
+                headers={"Authorization": f"Bearer {token}"},
+            )
+            assert add_response.status_code == 200
+
+    history_response = await client.get(
+        f"/api/rooms/{room_id}/messages",
+        headers={"Authorization": f"Bearer {owner_token}"},
+    )
+    assert history_response.status_code == 200
+    reactions = history_response.json()["messages"][0]["reactions"]
+    assert [reaction["emoji"] for reaction in reactions] == ["👍", "❤️", "😂"]
+    assert [reaction["count"] for reaction in reactions] == [3, 2, 2]
+
+
+async def test_deleted_message_cannot_be_reacted_to_and_reactions_are_removed(
+    client: AsyncClient, create_user, create_room, create_message
+):
+    """Deleted messages reject reactions and expose empty reaction summaries."""
+    user_data = await create_user(email="reactdelete@test.com", username="reactdelete")
+    token = user_data["access_token"]
+    room = await create_room(token, "Reaction Delete Room")
+    room_id = room["id"]
+    message = await create_message(token, room_id, "Delete with reactions")
+
+    add_response = await client.post(
+        f"/api/messages/{message['id']}/reactions",
+        json={"emoji": "🎉"},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert add_response.status_code == 200
+
+    delete_response = await client.delete(
+        f"/api/messages/{message['id']}",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert delete_response.status_code == 204
+
+    react_deleted_response = await client.post(
+        f"/api/messages/{message['id']}/reactions",
+        json={"emoji": "🎉"},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert react_deleted_response.status_code == 409
+
+    history_response = await client.get(
+        f"/api/rooms/{room_id}/messages",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert history_response.status_code == 200
+    deleted_message = history_response.json()["messages"][0]
+    assert deleted_message["deleted_at"] is not None
+    assert deleted_message["reactions"] == []
+
+
+async def test_reaction_endpoints_emit_ws_events_with_expected_payload(
+    monkeypatch,
+    client: AsyncClient,
+    create_user,
+    create_room,
+    create_message,
+):
+    """Reaction add/remove emit ws payload with required deterministic fields."""
+    user_data = await create_user(email="reactws@test.com", username="reactws")
+    token = user_data["access_token"]
+    room = await create_room(token, "Reaction WS Room")
+    room_id = room["id"]
+    message = await create_message(token, room_id, "Emit reaction events")
+
+    captured: list[tuple[int, dict]] = []
+
+    async def fake_broadcast(room_id: int, payload: dict, exclude=None):  # noqa: ANN001
+        captured.append((room_id, payload))
+
+    monkeypatch.setattr(
+        "app.api.messages.manager.broadcast_to_room",
+        fake_broadcast,
+    )
+
+    add_response = await client.post(
+        f"/api/messages/{message['id']}/reactions",
+        json={"emoji": "😂"},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    remove_response = await client.delete(
+        f"/api/messages/{message['id']}/reactions/%F0%9F%98%82",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+
+    assert add_response.status_code == 200
+    assert remove_response.status_code == 200
+    assert len(captured) == 2
+
+    added_room_id, added_payload = captured[0]
+    removed_room_id, removed_payload = captured[1]
+    assert added_room_id == room_id
+    assert removed_room_id == room_id
+    assert added_payload["type"] == "reaction_added"
+    assert removed_payload["type"] == "reaction_removed"
+    assert added_payload["reaction"] == {
+        "room_id": room_id,
+        "message_id": message["id"],
+        "emoji": "😂",
+        "user_id": user_data["user"]["id"],
+        "count": 1,
+    }
+    assert removed_payload["reaction"] == {
+        "room_id": room_id,
+        "message_id": message["id"],
+        "emoji": "😂",
+        "user_id": user_data["user"]["id"],
+        "count": 0,
+    }
+
+
+async def test_reaction_rate_limit_40_per_minute(
+    enable_rate_limiting,  # noqa: ARG001
+    client: AsyncClient,
+    create_user,
+    create_room,
+    create_message,
+):
+    """Reaction endpoint family allows 40/minute and rejects request 41."""
+    user_data = await create_user(email="reactratelimit@test.com", username="reactratelimit")
+    token = user_data["access_token"]
+    room = await create_room(token, "Reaction Rate Limit Room")
+    room_id = room["id"]
+    message = await create_message(token, room_id, "Rate limit reaction target")
+
+    status_codes: list[int] = []
+    for _ in range(41):
+        response = await client.post(
+            f"/api/messages/{message['id']}/reactions",
+            json={"emoji": "🔥"},
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        status_codes.append(response.status_code)
+
+    assert status_codes.count(200) == 40
+    assert status_codes[-1] == 429
+
+
+# ============================================================================
 # GET /api/rooms/:id/messages/:message_id/context
 # GET /api/rooms/:id/messages/newer
 # ============================================================================

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-Rostra is a real-time chat application. Users register and log in with username/password, discover and join named rooms, and send text messages. Messages are delivered in real time over WebSockets; the app also shows who is currently in each room (online users). Room access is controlled by explicit membership — users must join a room before they can view messages, send messages, or subscribe via WebSocket. Unread counts per room are tracked via a `user_room` table (last read timestamp) and cached in Redis with PostgreSQL fallback. Message history supports cursor-based pagination for infinite scroll. Rooms can be created and deleted (delete restricted to the room creator); members can leave rooms (except the creator). The stack is a React (Vite) frontend, FastAPI backend, PostgreSQL database, and Redis cache; all tables live in the `rostra` schema.
+Rostra is a real-time chat application. Users register and log in with username/password, discover and join named rooms, and send text messages. Messages are delivered in real time over WebSockets; the app also shows who is currently in each room (online users). Room access is controlled by explicit membership — users must join a room before they can view messages, send messages, react to messages, or subscribe via WebSocket. Unread counts per room are tracked via a `user_room` table (last read timestamp) and cached in Redis with PostgreSQL fallback. Message history supports cursor-based pagination for infinite scroll. Rooms can be created and deleted (delete restricted to the room creator); members can leave rooms (except the creator). The stack is a React (Vite) frontend, FastAPI backend, PostgreSQL database, and Redis cache; all tables live in the `rostra` schema.
 
 ## Tech Stack
 
@@ -71,21 +71,25 @@ All tables are in schema **rostra**.
 | **users**  | `id` (PK), `username`, `email`, `hashed_password`, `created_at` | User accounts; username and email unique. |
 | **rooms**  | `id` (PK), `name`, `created_by` (FK → users.id), `created_at` | Chat rooms; name unique. |
 | **messages** | `id` (PK), `room_id` (FK → rooms.id), `user_id` (FK → users.id), `content`, `created_at`, `edited_at` (nullable), `deleted_at` (nullable), `search_vector` (generated tsvector) | One message per row. Message edits update `content` and set `edited_at` while preserving `created_at`. Soft deletion sets `deleted_at` and scrubs `content` to empty string while preserving row position in history. `search_vector` is a stored generated column: `to_tsvector('english', content)`. |
+| **message_reactions** | `id` (PK), `message_id` (FK → messages.id ON DELETE CASCADE), `user_id` (FK → users.id ON DELETE CASCADE), `emoji`, `created_at` | Stores one emoji reaction row per `(message_id, user_id, emoji)`. Supports multiple different emojis per user on the same message while preventing same-emoji duplicates. |
 | **user_room** | `id` (PK), `user_id` (FK → users.id ON DELETE CASCADE), `room_id` (FK → rooms.id ON DELETE CASCADE), `last_read_at`, `joined_at` | Per-user read state per room; unique on (user_id, room_id). |
 
 ### Relationships
 
 - **users** → **messages**: one-to-many (user.messages).
+- **users** → **message_reactions**: one-to-many (user.message_reactions).
 - **users** → **rooms** (as creator): one-to-many (user.rooms, room.created_by).
 - **users** ↔ **rooms** (membership/read state): many-to-many via **user_room** (user.user_rooms, room.user_rooms).
 - **rooms** → **messages**: one-to-many with cascade delete (room.messages).
 - **rooms** → **user_room**: one-to-many with cascade delete.
+- **messages** → **message_reactions**: one-to-many with reaction cleanup on soft delete and FK cascade on hard delete.
 
 ### Indexes (from migrations and models)
 
 - **users**: `ix_users_id`, `ix_users_username` (unique), `ix_users_email` (unique).
 - **rooms**: `ix_rooms_id`, `ix_rooms_name` (unique).
 - **messages**: `ix_messages_id`, `ix_messages_room_created_id` composite index on `(room_id, created_at DESC, id DESC)` — covers cursor-based pagination queries (WHERE + ORDER BY + seek). `ix_messages_search_vector` GIN index on `search_vector` — covers full-text search queries (`@@` operator).
+- **message_reactions**: `ix_message_reactions_message_id` (message_id), `ix_message_reactions_user_id` (user_id), unique constraint `uq_message_reactions_message_user_emoji` on `(message_id, user_id, emoji)`.
 - **user_room**: `ix_user_room_user` (user_id), `ix_user_room_room` (room_id); unique constraint `uq_user_room` on (user_id, room_id).
 
 ## API Contracts
@@ -131,6 +135,8 @@ Base URL: `{API_URL}/api` (e.g. `http://localhost:8000/api`). Auth where require
 | POST   | /messages                | Yes  | Body: `MessageCreate` (room_id, content 1–1000 chars). Creates message as current user. 403 if not a room member. 404 if room not found. |
 | PATCH  | /messages/{message_id}   | Yes  | Edit message content. Authorization: message owner only. Body: `MessageUpdate` (content 1–1000 chars, trimmed). Rejects no-op edits after trimming (409) and edits to deleted messages (409). Returns updated `MessageResponse` including `edited_at`. Broadcasts `message_edited` event. **Rate limited: 20/min.** |
 | DELETE | /messages/{message_id}   | Yes  | Soft-delete message. Authorization: message owner OR room creator, with authz check before idempotency response. Behavior: set `deleted_at`, scrub `content` to empty string, keep row in timeline. Returns 204 for successful deletes and for already-deleted messages when caller is authorized. Broadcasts `message_deleted` event. **Rate limited: 20/min.** |
+| POST   | /messages/{message_id}/reactions | Yes | Add a caller-owned reaction using allowlisted emoji `👍 👎 ❤️ 😂 🔥 👀 🎉`. Caller must be a room member; deleted messages are non-reactable. Returns `MessageReactionUpdateResponse { message_id, room_id, reactions[] }`. Broadcasts `reaction_added` with delta payload `{ room_id, message_id, emoji, user_id, count }`. **Rate limited: 40/min.** |
+| DELETE | /messages/{message_id}/reactions/{emoji} | Yes | Remove caller-owned reaction for one emoji. Caller must be a room member and own the reaction row. Returns `MessageReactionUpdateResponse { message_id, room_id, reactions[] }`. Broadcasts `reaction_removed` delta payload with updated `count`. **Rate limited: 40/min.** |
 
 ### WebSocket
 
@@ -152,6 +158,8 @@ Base URL: `{API_URL}/api` (e.g. `http://localhost:8000/api`). Auth where require
 - `{ "type": "new_message", "message": { id, room_id, user_id, username, content, created_at, edited_at?, deleted_at? } }`
 - `{ "type": "message_edited", "message": { id, room_id, content, edited_at } }`
 - `{ "type": "message_deleted", "message": { id, room_id, deleted_at } }`
+- `{ "type": "reaction_added", "reaction": { room_id, message_id, emoji, user_id, count } }`
+- `{ "type": "reaction_removed", "reaction": { room_id, message_id, emoji, user_id, count } }`
 - `{ "type": "user_joined", "room_id": int, "user": { id, username } }`
 - `{ "type": "user_left", "room_id": int, "user": { id, username } }`
 - `{ "type": "typing_indicator", "room_id": int, "user": { id, username } }`
@@ -171,6 +179,7 @@ Base URL: `{API_URL}/api` (e.g. `http://localhost:8000/api`). Auth where require
 | Jump-to-message context | Two-phase context contract (`context` + `newer`) | `/messages/{id}/context` returns anchored window + `older_cursor`/`newer_cursor`; `/messages/newer` pages forward in ascending order. Keeps existing history/search contracts unchanged while enabling bidirectional context mode. |
 | Message history | REST for history, WS for live | Messages loaded via paginated GET endpoint; new messages pushed via WebSocket; no WS history replay. |
 | Message editing model | Owner-only PATCH + in-place WS update | PATCH `/messages/{id}` trims content, rejects no-op edits (`409`), blocks deleted-row edits, stamps `edited_at`, and broadcasts `message_edited` for in-place client updates without reordering. |
+| Message reactions model | Explicit add/remove endpoints + server-authoritative WS deltas | Reactions use allowlist `👍 👎 ❤️ 😂 🔥 👀 🎉`, unique `(message_id, user_id, emoji)` rows, member-only authz, and no optimistic final-state assumption on client. Deleted messages are non-reactable and soft-delete clears stored reactions. |
 | Async everywhere | AsyncSession, async CRUD, asyncpg | All endpoints use `async def`, all DB operations use `await`. WebSocket handlers create short-lived `AsyncSessionLocal()` sessions per message (like mini HTTP requests). |
 | Rate limiting | slowapi on abuse-prone endpoints | Register (5/min), login (10/min), join/leave (10/min), discover (30/min). Disabled in tests via high limits in conftest. |
 | Message deletion model | Soft delete + scrub | DELETE `/messages/{id}` keeps row in place, sets `deleted_at`, and scrubs `content` to empty string. Search excludes soft-deleted rows; authorized repeat delete is idempotent (204). |
@@ -198,6 +207,7 @@ app/
 │   ├── user.py
 │   ├── room.py
 │   ├── message.py
+│   ├── message_reaction.py
 │   └── user_room.py
 ├── schemas/                 # Pydantic request/response models
 │   ├── user.py

--- a/frontend/src/components/ChatLayout.tsx
+++ b/frontend/src/components/ChatLayout.tsx
@@ -21,6 +21,8 @@ import type {
   Room,
   WSDeletedMessagePayload,
   WSEditedMessagePayload,
+  WSMessageReactionAdded,
+  WSMessageReactionRemoved,
 } from "../types";
 
 // Keep a bounded subscription set so unread updates stay real-time without
@@ -88,6 +90,10 @@ export default function ChatLayout() {
   /** Message edits for the selected room delivered via WebSocket (processed then cleared). */
   const [incomingMessageEditsForRoom, setIncomingMessageEditsForRoom] = useState<
     WSEditedMessagePayload[]
+  >([]);
+  /** Message reactions for the selected room delivered via WebSocket (processed then cleared). */
+  const [incomingMessageReactionsForRoom, setIncomingMessageReactionsForRoom] = useState<
+    Array<WSMessageReactionAdded | WSMessageReactionRemoved>
   >([]);
   /** Snapshot of selected room's last_read_at at room-open time (used for stable new-message divider placement). */
   const [roomOpenLastReadSnapshot, setRoomOpenLastReadSnapshot] = useState<string | null>(null);
@@ -181,6 +187,7 @@ export default function ChatLayout() {
     setIncomingMessagesForRoom,
     setIncomingMessageDeletionsForRoom,
     setIncomingMessageEditsForRoom,
+    setIncomingMessageReactionsForRoom,
     setUnreadCounts,
     setLastReadAtByRoomId,
     setOnlineUsersByRoom,
@@ -202,6 +209,7 @@ export default function ChatLayout() {
     });
     setIncomingMessageDeletionsForRoom([]);
     setIncomingMessageEditsForRoom([]);
+    setIncomingMessageReactionsForRoom([]);
   };
 
   const cleanupRoomState = (roomId: number) => {
@@ -235,6 +243,7 @@ export default function ChatLayout() {
     setIncomingMessagesForRoom([]);
     setIncomingMessageDeletionsForRoom([]);
     setIncomingMessageEditsForRoom([]);
+    setIncomingMessageReactionsForRoom([]);
     setSidebarOpen(false);
 
     if (token) {
@@ -320,6 +329,7 @@ export default function ChatLayout() {
     setIncomingMessagesForRoom([]);
     setIncomingMessageDeletionsForRoom([]);
     setIncomingMessageEditsForRoom([]);
+    setIncomingMessageReactionsForRoom([]);
     logout(true);
   };
 
@@ -345,6 +355,10 @@ export default function ChatLayout() {
 
   const handleIncomingMessageEditsProcessed = () => {
     setIncomingMessageEditsForRoom([]);
+  };
+
+  const handleIncomingMessageReactionsProcessed = () => {
+    setIncomingMessageReactionsForRoom([]);
   };
 
   const handleOpenMessageContext = (context: MessageContextResponse) => {
@@ -453,6 +467,8 @@ export default function ChatLayout() {
           onIncomingMessageDeletionsProcessed={handleIncomingMessageDeletionsProcessed}
           incomingMessageEdits={incomingMessageEditsForRoom}
           onIncomingMessageEditsProcessed={handleIncomingMessageEditsProcessed}
+          incomingMessageReactions={incomingMessageReactionsForRoom}
+          onIncomingMessageReactionsProcessed={handleIncomingMessageReactionsProcessed}
           onToggleUsers={() => setRightPanel((prev) => prev === "users" ? "none" : "users")}
           onToggleSearch={() => setRightPanel((prev) => prev === "search" ? "none" : "search")}
           onRoomDeleted={handleRoomDeleted}

--- a/frontend/src/components/MessageArea.tsx
+++ b/frontend/src/components/MessageArea.tsx
@@ -7,6 +7,8 @@ import type {
   Room,
   WSDeletedMessagePayload,
   WSEditedMessagePayload,
+  WSMessageReactionAdded,
+  WSMessageReactionRemoved,
 } from "../types";
 import { useAuth } from "../context/AuthContext";
 import { useTheme } from "../context/ThemeContext";
@@ -30,6 +32,8 @@ interface MessageAreaProps {
   onIncomingMessageDeletionsProcessed?: () => void;
   incomingMessageEdits?: WSEditedMessagePayload[];
   onIncomingMessageEditsProcessed?: () => void;
+  incomingMessageReactions?: Array<WSMessageReactionAdded | WSMessageReactionRemoved>;
+  onIncomingMessageReactionsProcessed?: () => void;
   onToggleUsers: () => void;
   onToggleSearch: () => void;
   onRoomDeleted: () => void;
@@ -54,6 +58,8 @@ export default function MessageArea({
   onIncomingMessageDeletionsProcessed = () => {},
   incomingMessageEdits = [],
   onIncomingMessageEditsProcessed = () => {},
+  incomingMessageReactions = [],
+  onIncomingMessageReactionsProcessed = () => {},
   onToggleUsers,
   onToggleSearch,
   onRoomDeleted,
@@ -265,6 +271,8 @@ export default function MessageArea({
         onIncomingMessageDeletionsProcessed={onIncomingMessageDeletionsProcessed}
         incomingMessageEdits={incomingMessageEdits}
         onIncomingMessageEditsProcessed={onIncomingMessageEditsProcessed}
+        incomingMessageReactions={incomingMessageReactions}
+        onIncomingMessageReactionsProcessed={onIncomingMessageReactionsProcessed}
         scrollToLatestSignal={scrollToLatestSignal}
         onExitContextMode={onExitContextMode}
       />

--- a/frontend/src/components/MessageList.tsx
+++ b/frontend/src/components/MessageList.tsx
@@ -4,10 +4,18 @@ import { useTheme } from "../context/ThemeContext";
 import type {
   Message,
   MessageContextResponse,
+  ReactionEmoji,
   WSDeletedMessagePayload,
   WSEditedMessagePayload,
+  WSMessageReactionAdded,
+  WSMessageReactionRemoved,
 } from "../types";
-import { deleteMessage, editMessage } from "../services/api";
+import {
+  addMessageReaction,
+  deleteMessage,
+  editMessage,
+  removeMessageReaction,
+} from "../services/api";
 import { logError } from "../utils/logger";
 import { MessageFeedContent } from "./message-list/MessageFeedContent";
 import { DeleteMessageModal } from "./message-list/DeleteMessageModal";
@@ -27,6 +35,8 @@ interface MessageListProps {
   onIncomingMessageDeletionsProcessed?: () => void;
   incomingMessageEdits?: WSEditedMessagePayload[];
   onIncomingMessageEditsProcessed?: () => void;
+  incomingMessageReactions?: Array<WSMessageReactionAdded | WSMessageReactionRemoved>;
+  onIncomingMessageReactionsProcessed?: () => void;
   scrollToLatestSignal?: number;
   onExitContextMode?: () => void;
 }
@@ -44,6 +54,8 @@ export default function MessageList({
   onIncomingMessageDeletionsProcessed,
   incomingMessageEdits = [],
   onIncomingMessageEditsProcessed,
+  incomingMessageReactions = [],
+  onIncomingMessageReactionsProcessed,
   scrollToLatestSignal = 0,
   onExitContextMode,
 }: MessageListProps) {
@@ -56,6 +68,7 @@ export default function MessageList({
   const [editDraft, setEditDraft] = useState("");
   const [editError, setEditError] = useState("");
   const [savingMessageIds, setSavingMessageIds] = useState<number[]>([]);
+  const [pendingReactionKeys, setPendingReactionKeys] = useState<string[]>([]);
   const deleteModalRef = useRef<HTMLDivElement>(null);
   const {
     messages,
@@ -71,6 +84,7 @@ export default function MessageList({
     showContextLiveIndicator,
     jumpToLatest,
     applyMessageEdit,
+    applyMessageReactions,
     scrollContainerRef,
     sentinelRef,
     bottomSentinelRef,
@@ -89,6 +103,8 @@ export default function MessageList({
     onIncomingMessageDeletionsProcessed,
     incomingMessageEdits,
     onIncomingMessageEditsProcessed,
+    incomingMessageReactions,
+    onIncomingMessageReactionsProcessed,
     scrollToLatestSignal,
     onExitContextMode,
   });
@@ -160,6 +176,31 @@ export default function MessageList({
       }
     },
     [closeEditMode, handleSaveEdit],
+  );
+
+  const handleToggleReaction = useCallback(
+    async (messageId: number, emoji: ReactionEmoji, reactedByMe: boolean) => {
+      if (!token) return;
+
+      const reactionKey = `${messageId}:${emoji}`;
+      if (pendingReactionKeys.includes(reactionKey)) return;
+
+      setPendingReactionKeys((prev) =>
+        prev.includes(reactionKey) ? prev : [...prev, reactionKey],
+      );
+
+      try {
+        const response = reactedByMe
+          ? await removeMessageReaction(messageId, emoji, token)
+          : await addMessageReaction(messageId, emoji, token);
+        applyMessageReactions(messageId, response.reactions);
+      } catch (err) {
+        logError("Failed to toggle reaction:", err);
+      } finally {
+        setPendingReactionKeys((prev) => prev.filter((key) => key !== reactionKey));
+      }
+    },
+    [applyMessageReactions, pendingReactionKeys, token],
   );
 
   const handleConfirmDelete = useCallback(async () => {
@@ -280,12 +321,14 @@ export default function MessageList({
           editDraft={editDraft}
           editError={editError}
           savingMessageIds={savingMessageIds}
+          pendingReactionKeys={pendingReactionKeys}
           onDeleteMessage={handleDeleteMessage}
           onStartEdit={handleStartEdit}
           onEditDraftChange={setEditDraft}
           onEditKeyDown={handleEditKeyDown}
           onCancelEdit={closeEditMode}
           onSaveEdit={() => void handleSaveEdit()}
+          onToggleReaction={handleToggleReaction}
         />
 
         {isLoadingNewer && (

--- a/frontend/src/components/__tests__/ChatLayout.test.tsx
+++ b/frontend/src/components/__tests__/ChatLayout.test.tsx
@@ -39,6 +39,7 @@ type MessageAreaMockProps = {
   incomingMessages: Array<{ id: number }>;
   incomingMessageDeletions: Array<{ id: number }>;
   incomingMessageEdits: Array<{ id: number }>;
+  incomingMessageReactions: Array<{ type: string; reaction: { message_id: number } }>;
   wsError?: string | null;
   onLeaveRoom: () => void;
   onRoomDeleted: () => void;
@@ -115,6 +116,7 @@ vi.mock("../MessageArea", () => ({
     incomingMessages,
     incomingMessageDeletions,
     incomingMessageEdits,
+    incomingMessageReactions,
     wsError,
     onLeaveRoom,
     onRoomDeleted,
@@ -124,6 +126,7 @@ vi.mock("../MessageArea", () => ({
       <div data-testid="incoming-count">{incomingMessages.length}</div>
       <div data-testid="incoming-deletions-count">{incomingMessageDeletions.length}</div>
       <div data-testid="incoming-edits-count">{incomingMessageEdits.length}</div>
+      <div data-testid="incoming-reactions-count">{incomingMessageReactions.length}</div>
       <div data-testid="ws-error-text">{wsError ?? ""}</div>
       <button type="button" onClick={onLeaveRoom}>
         Leave Room
@@ -348,6 +351,39 @@ describe("ChatLayout", () => {
     });
     // Non-selected room edits are ignored in the selected-room queue.
     expect(screen.getByTestId("incoming-edits-count")).toHaveTextContent("1");
+  });
+
+  it("routes websocket reaction events to selected-room reaction queue", async () => {
+    render(<ChatLayout />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Select Room One" }));
+    await waitFor(() => {
+      expect(screen.getByTestId("selected-room-id")).toHaveTextContent("1");
+    });
+
+    emitWsMessage({
+      type: "reaction_added",
+      reaction: {
+        room_id: 1,
+        message_id: 301,
+        emoji: "👍",
+        user_id: 8,
+        count: 1,
+      },
+    });
+    expect(screen.getByTestId("incoming-reactions-count")).toHaveTextContent("1");
+
+    emitWsMessage({
+      type: "reaction_removed",
+      reaction: {
+        room_id: 2,
+        message_id: 301,
+        emoji: "👍",
+        user_id: 8,
+        count: 0,
+      },
+    });
+    expect(screen.getByTestId("incoming-reactions-count")).toHaveTextContent("1");
   });
 
   it("shows websocket errors and auto-clears the banner after four seconds", async () => {

--- a/frontend/src/components/__tests__/MessageList.test.tsx
+++ b/frontend/src/components/__tests__/MessageList.test.tsx
@@ -9,6 +9,8 @@ const mockGetRoomMessages = vi.fn();
 const mockGetRoomMessagesNewer = vi.fn();
 const mockDeleteMessage = vi.fn();
 const mockEditMessage = vi.fn();
+const mockAddMessageReaction = vi.fn();
+const mockRemoveMessageReaction = vi.fn();
 const mockOnIncomingMessagesProcessed = vi.fn();
 
 vi.mock("../../context/AuthContext", () => ({
@@ -34,6 +36,8 @@ vi.mock("../../services/api", () => ({
   getRoomMessagesNewer: (...args: unknown[]) => mockGetRoomMessagesNewer(...args),
   deleteMessage: (...args: unknown[]) => mockDeleteMessage(...args),
   editMessage: (...args: unknown[]) => mockEditMessage(...args),
+  addMessageReaction: (...args: unknown[]) => mockAddMessageReaction(...args),
+  removeMessageReaction: (...args: unknown[]) => mockRemoveMessageReaction(...args),
 }));
 
 function makeMessage(params: {
@@ -95,6 +99,8 @@ describe("MessageList", () => {
     mockGetRoomMessagesNewer.mockReset();
     mockDeleteMessage.mockReset();
     mockEditMessage.mockReset();
+    mockAddMessageReaction.mockReset();
+    mockRemoveMessageReaction.mockReset();
     mockOnIncomingMessagesProcessed.mockReset();
     mockDeleteMessage.mockResolvedValue({});
     mockEditMessage.mockImplementation(
@@ -108,6 +114,16 @@ describe("MessageList", () => {
           editedAt: "2024-01-01T10:01:00Z",
         }),
     );
+    mockAddMessageReaction.mockResolvedValue({
+      message_id: 1,
+      room_id: 1,
+      reactions: [{ emoji: "👍", count: 1, reacted_by_me: true }],
+    });
+    mockRemoveMessageReaction.mockResolvedValue({
+      message_id: 1,
+      room_id: 1,
+      reactions: [],
+    });
   });
 
   it("shows loading state while initial fetch is pending", async () => {
@@ -221,6 +237,75 @@ describe("MessageList", () => {
     expect(screen.queryByText("Original deleted content")).not.toBeInTheDocument();
   });
 
+  it("renders one reaction-menu trigger for active messages and hides it for deleted rows", async () => {
+    const activeMessage = makeMessage({
+      id: 8,
+      username: "alice",
+      content: "Active row",
+      createdAt: "2024-01-01T10:00:00Z",
+    });
+    const deletedMessage = makeMessage({
+      id: 9,
+      username: "bob",
+      content: "Deleted row content",
+      createdAt: "2024-01-01T10:01:00Z",
+      deletedAt: "2024-01-01T10:02:00Z",
+    });
+
+    mockGetRoomMessages.mockResolvedValueOnce({
+      messages: [deletedMessage, activeMessage],
+      next_cursor: null,
+    });
+
+    renderMessageList();
+    await screen.findByText("Active row");
+
+    const menuButtons = screen.getAllByRole("button", { name: "Open reaction menu" });
+    expect(menuButtons).toHaveLength(1);
+  });
+
+  it("toggles reactions via add/remove endpoints and applies server response", async () => {
+    const user = userEvent.setup();
+    const message = makeMessage({
+      id: 10,
+      userId: 2,
+      username: "bob",
+      content: "Toggle reactions here",
+      createdAt: "2024-01-01T10:00:00Z",
+    });
+
+    mockGetRoomMessages.mockResolvedValueOnce({
+      messages: [message],
+      next_cursor: null,
+    });
+    mockAddMessageReaction.mockResolvedValueOnce({
+      message_id: 10,
+      room_id: 1,
+      reactions: [{ emoji: "👍", count: 1, reacted_by_me: true }],
+    });
+    mockRemoveMessageReaction.mockResolvedValueOnce({
+      message_id: 10,
+      room_id: 1,
+      reactions: [],
+    });
+
+    renderMessageList();
+    await screen.findByText("Toggle reactions here");
+
+    await user.click(screen.getByRole("button", { name: "Open reaction menu" }));
+    await user.click(screen.getByRole("button", { name: "Add 👍 reaction" }));
+    await waitFor(() => {
+      expect(mockAddMessageReaction).toHaveBeenCalledWith(10, "👍", "test-token");
+    });
+    expect(screen.getByRole("button", { name: "Toggle 👍 reaction" })).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Open reaction menu" }));
+    await user.click(screen.getByRole("button", { name: "Remove 👍 reaction" }));
+    await waitFor(() => {
+      expect(mockRemoveMessageReaction).toHaveBeenCalledWith(10, "👍", "test-token");
+    });
+  });
+
   it("applies websocket deletion updates in place without removing the row", async () => {
     const first = makeMessage({
       id: 1,
@@ -316,6 +401,48 @@ describe("MessageList", () => {
     ).toBeTruthy();
     expect(screen.queryByText("Second message")).not.toBeInTheDocument();
     expect(screen.getByText("(edited)")).toBeInTheDocument();
+  });
+
+  it("applies websocket reaction updates in place", async () => {
+    const message = makeMessage({
+      id: 20,
+      username: "alice",
+      content: "Reaction target",
+      createdAt: "2024-01-01T10:00:00Z",
+    });
+
+    mockGetRoomMessages.mockResolvedValueOnce({
+      messages: [message],
+      next_cursor: null,
+    });
+
+    const { rerender } = renderMessageList();
+    await screen.findByText("Reaction target");
+
+    rerender(
+      <MessageList
+        roomId={1}
+        density="compact"
+        incomingMessages={[]}
+        incomingMessageReactions={[
+          {
+            type: "reaction_added",
+            reaction: {
+              room_id: 1,
+              message_id: 20,
+              emoji: "🔥",
+              user_id: 9,
+              count: 1,
+            },
+          },
+        ]}
+        onIncomingMessagesProcessed={mockOnIncomingMessagesProcessed}
+        onIncomingMessageReactionsProcessed={vi.fn()}
+        scrollToLatestSignal={0}
+      />,
+    );
+
+    expect(await screen.findByRole("button", { name: "Toggle 🔥 reaction" })).toBeInTheDocument();
   });
 
   it("shows in-app delete confirmation modal and calls delete API on confirm", async () => {

--- a/frontend/src/components/message-list/MessageFeedContent.tsx
+++ b/frontend/src/components/message-list/MessageFeedContent.tsx
@@ -1,5 +1,5 @@
 import type { KeyboardEvent } from "react";
-import type { Message } from "../../types";
+import type { Message, ReactionEmoji } from "../../types";
 import {
   getDateLabel,
   getFullDateTime,
@@ -25,12 +25,14 @@ interface MessageFeedContentProps {
   editDraft: string;
   editError: string;
   savingMessageIds: number[];
+  pendingReactionKeys: string[];
   onDeleteMessage: (messageId: number) => void;
   onStartEdit: (messageId: number, content: string) => void;
   onEditDraftChange: (value: string) => void;
   onEditKeyDown: (event: KeyboardEvent<HTMLTextAreaElement>) => void;
   onCancelEdit: () => void;
   onSaveEdit: () => void;
+  onToggleReaction: (messageId: number, emoji: ReactionEmoji, reactedByMe: boolean) => void;
 }
 
 export function MessageFeedContent({
@@ -46,12 +48,14 @@ export function MessageFeedContent({
   editDraft,
   editError,
   savingMessageIds,
+  pendingReactionKeys,
   onDeleteMessage,
   onStartEdit,
   onEditDraftChange,
   onEditKeyDown,
   onCancelEdit,
   onSaveEdit,
+  onToggleReaction,
 }: MessageFeedContentProps) {
   const isComfortableDensity = density === "comfortable";
 
@@ -93,6 +97,7 @@ export function MessageFeedContent({
           (message.user_id === currentUserId || roomCreatorId === currentUserId);
         const canEdit =
           !message.deleted_at && currentUserId != null && message.user_id === currentUserId;
+        const canReact = !message.deleted_at && currentUserId != null;
         const isDeleting = deletingMessageIds.includes(message.id);
         const isEditing = editingMessageId === message.id;
         const isSavingEdit = savingMessageIds.includes(message.id);
@@ -181,12 +186,15 @@ export function MessageFeedContent({
               isSavingEdit={isSavingEdit}
               editDraft={editDraft}
               editError={isEditing ? editError : ""}
+              canReact={canReact}
+              pendingReactionKeys={pendingReactionKeys}
               onStartEdit={onStartEdit}
               onEditDraftChange={onEditDraftChange}
               onEditKeyDown={onEditKeyDown}
               onCancelEdit={onCancelEdit}
               onSaveEdit={onSaveEdit}
               onDeleteMessage={onDeleteMessage}
+              onToggleReaction={onToggleReaction}
             />
           </div>
         );

--- a/frontend/src/components/message-list/MessageRow.tsx
+++ b/frontend/src/components/message-list/MessageRow.tsx
@@ -1,6 +1,7 @@
-import { useEffect, useRef, type KeyboardEvent } from "react";
+import { useEffect, useRef, useState, type KeyboardEvent } from "react";
 import { getUserColorPalette } from "../../utils/userColors";
-import type { Message } from "../../types";
+import type { Message, ReactionEmoji } from "../../types";
+import { REACTION_ALLOWLIST, sortReactions } from "./reactionConfig";
 
 interface MessageRowProps {
   message: Message;
@@ -15,17 +16,20 @@ interface MessageRowProps {
   editedFullDateTime: string;
   canEdit: boolean;
   canDelete: boolean;
+  canReact: boolean;
   isEditing: boolean;
   isDeleting: boolean;
   isSavingEdit: boolean;
   editDraft: string;
   editError: string;
+  pendingReactionKeys: string[];
   onStartEdit: (messageId: number, content: string) => void;
   onEditDraftChange: (value: string) => void;
   onEditKeyDown: (event: KeyboardEvent<HTMLTextAreaElement>) => void;
   onCancelEdit: () => void;
   onSaveEdit: () => void;
   onDeleteMessage: (messageId: number) => void;
+  onToggleReaction: (messageId: number, emoji: ReactionEmoji, reactedByMe: boolean) => void;
 }
 
 export function MessageRow({
@@ -41,23 +45,32 @@ export function MessageRow({
   editedFullDateTime,
   canEdit,
   canDelete,
+  canReact,
   isEditing,
   isDeleting,
   isSavingEdit,
   editDraft,
   editError,
+  pendingReactionKeys,
   onStartEdit,
   onEditDraftChange,
   onEditKeyDown,
   onCancelEdit,
   onSaveEdit,
   onDeleteMessage,
+  onToggleReaction,
 }: MessageRowProps) {
   // Keep amber visuals cohesive by using per-user hues only in neon mode.
   const userColors = theme === "neon" ? getUserColorPalette(message.username) : null;
   const isDeleted = Boolean(message.deleted_at);
   const isEdited = Boolean(message.edited_at);
+  const reactions = sortReactions(message.reactions ?? []);
+  const visibleReactions = reactions.slice(0, 5);
+  const overflowReactionsCount = Math.max(0, reactions.length - visibleReactions.length);
   const editTextareaRef = useRef<HTMLTextAreaElement | null>(null);
+  const [reactionMenuOpen, setReactionMenuOpen] = useState(false);
+
+  const getReactionKey = (emoji: ReactionEmoji): string => `${message.id}:${emoji}`;
 
   useEffect(() => {
     if (!isEditing) return;
@@ -69,6 +82,8 @@ export function MessageRow({
     textarea.focus();
     textarea.setSelectionRange(cursorAtEnd, cursorAtEnd);
   }, [isEditing]);
+
+  const reactionMenuVisible = reactionMenuOpen && !isEditing && !isDeleted;
 
   return (
     <div
@@ -240,11 +255,118 @@ export function MessageRow({
                     (edited)
                   </span>
                 )}
+                {reactions.length > 0 && (
+                  <div className="mt-2 flex items-center gap-1 flex-wrap">
+                    {visibleReactions.map((reaction) => (
+                      <button
+                        key={reaction.emoji}
+                        type="button"
+                        disabled={pendingReactionKeys.includes(getReactionKey(reaction.emoji))}
+                        onClick={() =>
+                          onToggleReaction(
+                            message.id,
+                            reaction.emoji,
+                            reaction.reacted_by_me,
+                          )
+                        }
+                        className="font-mono text-[10px] px-2 py-0.5 border transition-colors"
+                        style={{
+                          color: reaction.reacted_by_me
+                            ? "var(--color-primary)"
+                            : "var(--color-meta)",
+                          borderColor: reaction.reacted_by_me
+                            ? "var(--color-primary)"
+                            : "var(--border-dim)",
+                          background: reaction.reacted_by_me
+                            ? "color-mix(in srgb, var(--color-primary) 10%, transparent)"
+                            : "transparent",
+                        }}
+                        aria-label={`Toggle ${reaction.emoji} reaction`}
+                      >
+                        {reaction.emoji} {reaction.count}
+                      </button>
+                    ))}
+                    {overflowReactionsCount > 0 && (
+                      <span
+                        className="font-mono text-[10px] px-2 py-0.5 border"
+                        style={{
+                          color: "var(--color-meta)",
+                          borderColor: "var(--border-dim)",
+                        }}
+                        aria-label={`${overflowReactionsCount} more reactions`}
+                      >
+                        +{overflowReactionsCount}
+                      </span>
+                    )}
+                  </div>
+                )}
               </>
             )}
           </div>
-          {!isEditing && (canEdit || canDelete) && (
-            <div className="flex items-center gap-1 opacity-0 group-hover:opacity-100 transition-opacity shrink-0">
+          {!isEditing && (canEdit || canDelete || canReact) && (
+            <div className="relative flex items-center gap-1 opacity-0 group-hover:opacity-100 transition-opacity shrink-0">
+              {canReact && (
+                <>
+                  <button
+                    type="button"
+                    onClick={() => setReactionMenuOpen((prev) => !prev)}
+                    className="font-mono text-[10px] tracking-[0.08em] px-2 py-1 border"
+                    style={{
+                      color: "var(--color-meta)",
+                      borderColor: "var(--border-dim)",
+                      background: "transparent",
+                    }}
+                    aria-label={reactionMenuVisible ? "Close reaction menu" : "Open reaction menu"}
+                  >
+                    REACT
+                  </button>
+                  {reactionMenuVisible && (
+                    <div
+                      className="absolute right-0 top-full mt-1 z-10 p-1.5 border flex items-center gap-1"
+                      style={{
+                        background: "var(--bg-panel)",
+                        borderColor: "var(--border-dim)",
+                      }}
+                    >
+                      {REACTION_ALLOWLIST.map((emoji) => {
+                        const matchingReaction = reactions.find(
+                          (reaction) => reaction.emoji === emoji,
+                        );
+                        const reactedByMe = matchingReaction?.reacted_by_me ?? false;
+                        const reactionPending = pendingReactionKeys.includes(getReactionKey(emoji));
+
+                        return (
+                          <button
+                            key={emoji}
+                            type="button"
+                            disabled={reactionPending}
+                            onClick={() => {
+                              onToggleReaction(message.id, emoji, reactedByMe);
+                              setReactionMenuOpen(false);
+                            }}
+                            className="font-mono text-[12px] px-1.5 py-0.5 border transition-colors"
+                            style={{
+                              color: reactedByMe ? "var(--color-primary)" : "var(--color-meta)",
+                              borderColor: reactedByMe
+                                ? "var(--color-primary)"
+                                : "var(--border-dim)",
+                              background: reactedByMe
+                                ? "color-mix(in srgb, var(--color-primary) 10%, transparent)"
+                                : "transparent",
+                              opacity: reactionPending ? 0.55 : 1,
+                            }}
+                            aria-label={
+                              reactedByMe ? `Remove ${emoji} reaction` : `Add ${emoji} reaction`
+                            }
+                          >
+                            {emoji}
+                          </button>
+                        );
+                      })}
+                    </div>
+                  )}
+                </>
+              )}
               {canEdit && (
                 <button
                   type="button"

--- a/frontend/src/components/message-list/reactionConfig.ts
+++ b/frontend/src/components/message-list/reactionConfig.ts
@@ -1,0 +1,28 @@
+import type { MessageReactionSummary, ReactionEmoji } from "../../types";
+
+export const REACTION_ALLOWLIST: ReactionEmoji[] = [
+  "👍",
+  "👎",
+  "❤️",
+  "😂",
+  "🔥",
+  "👀",
+  "🎉",
+];
+
+const reactionOrder = new Map(
+  REACTION_ALLOWLIST.map((emoji, index) => [emoji, index]),
+);
+
+export function sortReactions(
+  reactions: MessageReactionSummary[],
+): MessageReactionSummary[] {
+  return [...reactions].sort((left, right) => {
+    if (left.count !== right.count) {
+      return right.count - left.count;
+    }
+    const leftOrder = reactionOrder.get(left.emoji) ?? REACTION_ALLOWLIST.length;
+    const rightOrder = reactionOrder.get(right.emoji) ?? REACTION_ALLOWLIST.length;
+    return leftOrder - rightOrder;
+  });
+}

--- a/frontend/src/context/webSocketContextState.ts
+++ b/frontend/src/context/webSocketContextState.ts
@@ -1,5 +1,7 @@
 import { createContext, useContext } from "react";
 import type {
+  WSMessageReactionAdded,
+  WSMessageReactionRemoved,
   WSMessageEdited,
   WSMessageDeleted,
   WSNewMessage,
@@ -14,6 +16,8 @@ export type WebSocketMessage =
   | WSNewMessage
   | WSMessageEdited
   | WSMessageDeleted
+  | WSMessageReactionAdded
+  | WSMessageReactionRemoved
   | WSUserJoined
   | WSUserLeft
   | WSError

--- a/frontend/src/hooks/useChatLayoutMessageHandler.ts
+++ b/frontend/src/hooks/useChatLayoutMessageHandler.ts
@@ -12,6 +12,8 @@ import type {
   Room,
   WSDeletedMessagePayload,
   WSEditedMessagePayload,
+  WSMessageReactionAdded,
+  WSMessageReactionRemoved,
 } from "../types";
 
 /**
@@ -35,6 +37,9 @@ interface UseChatLayoutMessageHandlerParams {
   setIncomingMessagesForRoom: Dispatch<SetStateAction<Message[]>>;
   setIncomingMessageDeletionsForRoom: Dispatch<SetStateAction<WSDeletedMessagePayload[]>>;
   setIncomingMessageEditsForRoom: Dispatch<SetStateAction<WSEditedMessagePayload[]>>;
+  setIncomingMessageReactionsForRoom: Dispatch<
+    SetStateAction<Array<WSMessageReactionAdded | WSMessageReactionRemoved>>
+  >;
   setUnreadCounts: Dispatch<SetStateAction<Record<number, number>>>;
   setLastReadAtByRoomId: Dispatch<SetStateAction<Record<number, string | null>>>;
   setOnlineUsersByRoom: Dispatch<SetStateAction<Record<number, OnlineUser[]>>>;
@@ -51,6 +56,7 @@ export function useChatLayoutMessageHandler({
   setIncomingMessagesForRoom,
   setIncomingMessageDeletionsForRoom,
   setIncomingMessageEditsForRoom,
+  setIncomingMessageReactionsForRoom,
   setUnreadCounts,
   setLastReadAtByRoomId,
   setOnlineUsersByRoom,
@@ -71,6 +77,8 @@ export function useChatLayoutMessageHandler({
         message.type === "message_deleted" ||
         message.type === "message_edited"
           ? message.message.room_id
+          : message.type === "reaction_added" || message.type === "reaction_removed"
+            ? message.reaction.room_id
           : "room_id" in message
             ? message.room_id
             : null;
@@ -127,6 +135,16 @@ export function useChatLayoutMessageHandler({
         if (messageRoomId === selectedRoomRef.current?.id) {
           // Keep edit updates queued so MessageList mutates rows in place.
           setIncomingMessageEditsForRoom((prev) => [...prev, message.message]);
+        }
+        return;
+      }
+
+      if (
+        (message.type === "reaction_added" || message.type === "reaction_removed") &&
+        messageRoomId != null
+      ) {
+        if (messageRoomId === selectedRoomRef.current?.id) {
+          setIncomingMessageReactionsForRoom((prev) => [...prev, message]);
         }
         return;
       }
@@ -199,6 +217,7 @@ export function useChatLayoutMessageHandler({
     setIncomingMessagesForRoom,
     setIncomingMessageDeletionsForRoom,
     setIncomingMessageEditsForRoom,
+    setIncomingMessageReactionsForRoom,
     setLastReadAtByRoomId,
     setOnlineUsersByRoom,
     setTypingUsersByRoom,

--- a/frontend/src/hooks/useMessageFeedLifecycle.ts
+++ b/frontend/src/hooks/useMessageFeedLifecycle.ts
@@ -5,8 +5,11 @@ import { logError } from "../utils/logger";
 import type {
   Message,
   MessageContextResponse,
+  MessageReactionSummary,
   WSDeletedMessagePayload,
   WSEditedMessagePayload,
+  WSMessageReactionAdded,
+  WSMessageReactionRemoved,
 } from "../types";
 import {
   capturePrependAnchor,
@@ -14,6 +17,7 @@ import {
   isStrictlyNewerThan,
   type ChatItem,
 } from "../components/message-list/messageListFormatting";
+import { sortReactions } from "../components/message-list/reactionConfig";
 import {
   useMessageFeedViewport,
   type PendingScrollAdjustment,
@@ -40,6 +44,8 @@ interface UseMessageFeedLifecycleParams {
   onIncomingMessageDeletionsProcessed?: () => void;
   incomingMessageEdits: WSEditedMessagePayload[];
   onIncomingMessageEditsProcessed?: () => void;
+  incomingMessageReactions: Array<WSMessageReactionAdded | WSMessageReactionRemoved>;
+  onIncomingMessageReactionsProcessed?: () => void;
   scrollToLatestSignal: number;
   onExitContextMode?: () => void;
 }
@@ -61,6 +67,10 @@ interface UseMessageFeedLifecycleResult {
     messageId: number,
     content: string,
     editedAt: string | null,
+  ) => void;
+  applyMessageReactions: (
+    messageId: number,
+    reactions: MessageReactionSummary[],
   ) => void;
   scrollContainerRef: RefObject<HTMLDivElement | null>;
   sentinelRef: RefObject<HTMLDivElement | null>;
@@ -86,6 +96,8 @@ export function useMessageFeedLifecycle({
   onIncomingMessageDeletionsProcessed,
   incomingMessageEdits,
   onIncomingMessageEditsProcessed,
+  incomingMessageReactions,
+  onIncomingMessageReactionsProcessed,
   scrollToLatestSignal,
   onExitContextMode,
 }: UseMessageFeedLifecycleParams): UseMessageFeedLifecycleResult {
@@ -471,6 +483,7 @@ export function useMessageFeedLifecycle({
           ...item,
           content: "",
           deleted_at: deletion.deleted_at,
+          reactions: [],
         };
       }),
     );
@@ -483,6 +496,7 @@ export function useMessageFeedLifecycle({
           ...item,
           content: "",
           deleted_at: deletion.deleted_at,
+          reactions: [],
         };
       }),
     );
@@ -523,6 +537,60 @@ export function useMessageFeedLifecycle({
     onIncomingMessageEditsProcessed?.();
   }, [incomingMessageEdits, onIncomingMessageEditsProcessed]);
 
+  useEffect(() => {
+    if (incomingMessageReactions.length === 0) return;
+
+    const applyReactionEvents = (target: Message): Message => {
+      const nextReactions = [...(target.reactions ?? [])];
+
+      incomingMessageReactions.forEach((event) => {
+        if (event.reaction.message_id !== target.id) return;
+
+        const { emoji, count, user_id: actorId } = event.reaction;
+        const existingIndex = nextReactions.findIndex((entry) => entry.emoji === emoji);
+
+        if (count <= 0) {
+          if (existingIndex >= 0) {
+            nextReactions.splice(existingIndex, 1);
+          }
+          return;
+        }
+
+        const existing = existingIndex >= 0 ? nextReactions[existingIndex] : null;
+        const reactedByMe =
+          actorId === userId
+            ? event.type === "reaction_added"
+            : (existing?.reacted_by_me ?? false);
+        const updated = {
+          emoji,
+          count,
+          reacted_by_me: reactedByMe,
+        };
+
+        if (existingIndex >= 0) {
+          nextReactions[existingIndex] = updated;
+        } else {
+          nextReactions.push(updated);
+        }
+      });
+
+      return {
+        ...target,
+        reactions: sortReactions(nextReactions),
+      };
+    };
+
+    setMessages((prev) =>
+      prev.map((item) => {
+        if ("type" in item) return item;
+        return applyReactionEvents(item);
+      }),
+    );
+
+    setContextLiveMessages((prev) => prev.map((item) => applyReactionEvents(item)));
+    onIncomingMessageReactionsProcessed?.();
+  }, [incomingMessageReactions, onIncomingMessageReactionsProcessed, userId]);
+
   const showContextLiveIndicator =
     messageViewMode === "context" && contextLiveMessages.length > 0;
 
@@ -546,6 +614,28 @@ export function useMessageFeedLifecycle({
     [],
   );
 
+  const applyMessageReactions = useCallback(
+    (messageId: number, reactions: MessageReactionSummary[]) => {
+      const sorted = sortReactions(reactions);
+
+      setMessages((prev) =>
+        prev.map((item) => {
+          if ("type" in item) return item;
+          if (item.id !== messageId) return item;
+          return { ...item, reactions: sorted };
+        }),
+      );
+
+      setContextLiveMessages((prev) =>
+        prev.map((item) => {
+          if (item.id !== messageId) return item;
+          return { ...item, reactions: sorted };
+        }),
+      );
+    },
+    [],
+  );
+
   return {
     messages,
     loading,
@@ -560,6 +650,7 @@ export function useMessageFeedLifecycle({
     showContextLiveIndicator,
     jumpToLatest,
     applyMessageEdit,
+    applyMessageReactions,
     scrollContainerRef,
     sentinelRef,
     bottomSentinelRef,

--- a/frontend/src/services/__tests__/api.test.ts
+++ b/frontend/src/services/__tests__/api.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { delay, http, HttpResponse } from "msw";
 import { server } from "../../test/mocks/server";
 import {
+  addMessageReaction,
   deleteMessage,
   deleteRoom,
   getMessageContext,
@@ -9,6 +10,7 @@ import {
   getRoomMessages,
   getRoomMessagesNewer,
   login,
+  removeMessageReaction,
   setUnauthorizedHandler,
 } from "../api";
 
@@ -217,5 +219,46 @@ describe("api service", () => {
     );
 
     await expect(deleteMessage(42, "test-token")).resolves.toEqual({});
+  });
+
+  it("calls add reaction endpoint and returns updated summary payload", async () => {
+    server.use(
+      http.post("*/api/messages/:messageId/reactions", () =>
+        HttpResponse.json({
+          message_id: 42,
+          room_id: 7,
+          reactions: [{ emoji: "👍", count: 1, reacted_by_me: true }],
+        }),
+      ),
+    );
+
+    await expect(
+      addMessageReaction(42, "👍", "test-token"),
+    ).resolves.toEqual({
+      message_id: 42,
+      room_id: 7,
+      reactions: [{ emoji: "👍", count: 1, reacted_by_me: true }],
+    });
+  });
+
+  it("calls remove reaction endpoint with encoded emoji", async () => {
+    server.use(
+      http.delete("*/api/messages/:messageId/reactions/:emoji", ({ params }) => {
+        expect(params.emoji).toBe("❤️");
+        return HttpResponse.json({
+          message_id: 42,
+          room_id: 7,
+          reactions: [],
+        });
+      }),
+    );
+
+    await expect(
+      removeMessageReaction(42, "❤️", "test-token"),
+    ).resolves.toEqual({
+      message_id: 42,
+      room_id: 7,
+      reactions: [],
+    });
   });
 });

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -7,6 +7,8 @@ import type {
   Message,
   PaginatedMessages,
   MessageContextResponse,
+  MessageReactionUpdateResponse,
+  ReactionEmoji,
 } from "../types";
 
 // Central API client used by all frontend features.
@@ -432,4 +434,34 @@ export async function deleteMessage(
       Authorization: `Bearer ${token}`,
     },
   });
+}
+
+export async function addMessageReaction(
+  messageId: number,
+  emoji: ReactionEmoji,
+  token: string,
+): Promise<MessageReactionUpdateResponse> {
+  return apiCall<MessageReactionUpdateResponse>(`/messages/${messageId}/reactions`, {
+    method: "POST",
+    body: JSON.stringify({ emoji }),
+    headers: {
+      Authorization: `Bearer ${token}`,
+    },
+  });
+}
+
+export async function removeMessageReaction(
+  messageId: number,
+  emoji: ReactionEmoji,
+  token: string,
+): Promise<MessageReactionUpdateResponse> {
+  return apiCall<MessageReactionUpdateResponse>(
+    `/messages/${messageId}/reactions/${encodeURIComponent(emoji)}`,
+    {
+      method: "DELETE",
+      headers: {
+        Authorization: `Bearer ${token}`,
+      },
+    },
+  );
 }

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -40,6 +40,14 @@ export interface Room {
 }
 
 // Message types
+export type ReactionEmoji = "👍" | "👎" | "❤️" | "😂" | "🔥" | "👀" | "🎉";
+
+export interface MessageReactionSummary {
+  emoji: ReactionEmoji;
+  count: number;
+  reacted_by_me: boolean;
+}
+
 export interface Message {
   id: number;
   room_id: number;
@@ -49,6 +57,7 @@ export interface Message {
   created_at: string;
   edited_at?: string | null;
   deleted_at?: string | null;
+  reactions?: MessageReactionSummary[];
 }
 
 export interface PaginatedMessages {
@@ -61,6 +70,12 @@ export interface MessageContextResponse {
   target_message_id: number;
   older_cursor: string | null;
   newer_cursor: string | null;
+}
+
+export interface MessageReactionUpdateResponse {
+  message_id: number;
+  room_id: number;
+  reactions: MessageReactionSummary[];
 }
 
 // WebSocket message types
@@ -108,6 +123,24 @@ export interface WSMessageEdited {
   message: WSEditedMessagePayload;
 }
 
+export interface WSReactionPayload {
+  room_id: number;
+  message_id: number;
+  emoji: ReactionEmoji;
+  user_id: number;
+  count: number;
+}
+
+export interface WSMessageReactionAdded {
+  type: "reaction_added";
+  reaction: WSReactionPayload;
+}
+
+export interface WSMessageReactionRemoved {
+  type: "reaction_removed";
+  reaction: WSReactionPayload;
+}
+
 export interface WSUserJoined {
   type: "user_joined";
   room_id: number;
@@ -153,6 +186,8 @@ export type WebSocketMessage =
   | WSNewMessage
   | WSMessageEdited
   | WSMessageDeleted
+  | WSMessageReactionAdded
+  | WSMessageReactionRemoved
   | WSUserJoined
   | WSUserLeft
   | WSError

--- a/plans/3-5-message-reactions-whiteboard.md
+++ b/plans/3-5-message-reactions-whiteboard.md
@@ -1,0 +1,93 @@
+## Feature
+Phase 3.5 - Message Reactions (`docs/specs/frontend-design-audit.md`)
+
+## Execution Mode
+`single` (default): one Task issue -> one PR -> closes Task issue.
+
+## Goal
+Add server-authoritative message reactions end-to-end (DB + API + WS + frontend) with the locked v1 emoji set and deterministic reaction pill behavior.
+
+## Scope
+**In:**
+- `message_reactions` persistence with uniqueness per (`message_id`, `user_id`, `emoji`).
+- Add/remove reaction endpoints for authenticated room members.
+- Reaction summary in message payloads (`emoji`, `count`, `reacted_by_me`).
+- WS reaction delta events and frontend in-place updates.
+- Reaction UI under each message with overflow and ordering rules.
+- Backend/frontend tests for authz, deleted-message behavior, sorting, and WS sync.
+
+**Out:**
+- Custom emoji picker/full emoji keyboard.
+- Optimistic final-state assumptions on client.
+- Any non-3.5 feature work.
+
+## Locked Decisions Check (3.5)
+- [x] Emoji allowlist: `👍 👎 ❤️ 😂 🔥 👀 🎉`
+- [x] Multi-emoji per user (one row per emoji, same user can apply multiple different emojis)
+- [x] Authz: authenticated room member can add/remove own reactions
+- [x] Deleted message is non-reactable; deleted rows render no reaction controls
+- [x] Deleting a message removes its stored reactions
+- [x] UI shows max 5 pills, then `+N`
+- [x] Pill order: count desc, tie-break by allowlist order
+- [x] API shape: explicit add/remove endpoints (`POST`, `DELETE`)
+- [x] WS payload contains `room_id`, `message_id`, `emoji`, `user_id`, `count`
+- [x] Server-authoritative updates only (no optimistic final state)
+- [x] Rate limit: `40/minute` on reaction endpoint family
+
+## Files Planned
+Backend:
+- `backend/app/models/message_reaction.py` (new model)
+- `backend/app/models/message.py` (relationship + cascade)
+- `backend/app/models/user.py` (relationship)
+- `backend/alembic/versions/*_add_message_reactions_table.py`
+- `backend/app/schemas/message.py` (reaction schemas + message response extension)
+- `backend/app/crud/message.py` (reaction add/remove + aggregated summary queries)
+- `backend/app/api/messages.py` (new endpoints + include reactions in responses)
+- `backend/app/websocket/schemas.py` (reaction event payload schemas)
+- `backend/tests/test_messages.py` (reaction endpoint + WS + deleted-message behavior tests)
+
+Frontend:
+- `frontend/src/types/index.ts` (reaction types + WS reaction events)
+- `frontend/src/services/api.ts` (add/remove reaction API calls)
+- `frontend/src/hooks/useChatLayoutMessageHandler.ts` (queue reaction WS events for selected room)
+- `frontend/src/components/ChatLayout.tsx` (reaction queue state + plumbing)
+- `frontend/src/hooks/useMessageFeedLifecycle.ts` (apply reaction deltas server-authoritatively)
+- `frontend/src/components/message-list/MessageRow.tsx` (reaction bar + pill rendering + overflow)
+- `frontend/src/components/message-list/MessageFeedContent.tsx` (pass reaction handlers/props)
+- `frontend/src/components/MessageList.tsx` (invoke reaction APIs, in-flight state, guard deleted rows)
+- `frontend/src/components/__tests__/MessageList.test.tsx`
+- `frontend/src/components/__tests__/ChatLayout.test.tsx`
+- `frontend/src/services/__tests__/api.test.ts`
+
+Docs:
+- `backend/TESTPLAN.md` (add reaction cases before writing tests)
+- `docs/ARCHITECTURE.md` (new table, endpoints, WS event types)
+
+## Implementation Steps (Checklist)
+1. Update `backend/TESTPLAN.md` and frontend test plan section with 3.5 cases.
+2. Add DB model + migration for `message_reactions` with unique/index constraints.
+3. Extend backend schemas/crud to return ordered reaction summaries in message payloads.
+4. Add reaction endpoints with membership + own-reaction checks and `40/minute` rate limit.
+5. Emit WS `reaction_added` / `reaction_removed` delta events after successful mutations.
+6. Ensure delete flow removes reaction rows (DB cascade + test).
+7. Add frontend types/API methods + reaction delta handling in ChatLayout/message lifecycle.
+8. Render reaction bar with allowlist, max-5 + `+N`, deterministic sort, deleted-message guard.
+9. Add backend/frontend tests for locks and regressions.
+10. Run required verification commands and update docs for implemented contracts.
+
+## Verification Plan
+Backend:
+```bash
+make backend-verify
+```
+
+Frontend:
+```bash
+cd frontend && npx tsc --noEmit
+cd frontend && npx eslint src/
+cd frontend && npm run build
+```
+
+## Risks / Notes
+- Main correctness risk is drift between API response summaries and WS delta updates; mitigation is server-authoritative summary recalculation on every API response and deterministic WS payload handling.
+- Deletion cascade must be enforced at DB level to guarantee reaction cleanup even if deletion path changes later.

--- a/plans/task-3-5-message-reactions-01.md
+++ b/plans/task-3-5-message-reactions-01.md
@@ -1,0 +1,68 @@
+## Goal
+Deliver Phase 3.5 Message Reactions end-to-end (DB + API + WS + frontend) with deterministic, server-authoritative reaction state.
+
+Suggested labels: `type:task`, `phase:3`, `area:backend`, `area:frontend`, `area:db`, `area:ws`, `area:tests`, `status:ready`
+
+## Scope
+**In:**
+- Add `message_reactions` storage and migration.
+- Add add/remove reaction endpoints for room members.
+- Include ordered reaction summary in message payloads.
+- Broadcast WS reaction delta events and apply them client-side in place.
+- Render reaction pills under messages with lock-defined ordering/overflow behavior.
+- Add backend/frontend tests covering authorization, deleted-message constraints, ordering, and realtime updates.
+
+**Out:**
+- Full emoji picker.
+- Optimistic final-state UI assumptions.
+- Non-3.5 feature work.
+
+## Implementation notes
+1. Use emoji allowlist constants on backend and frontend: `👍 👎 ❤️ 😂 🔥 👀 🎉`.
+2. Enforce uniqueness (`message_id`, `user_id`, `emoji`) and treat client toggle behavior as explicit add/remove API calls.
+3. For every API message response, return reaction summary entries sorted by count desc then allowlist order.
+4. WS reaction events carry `{ room_id, message_id, emoji, user_id, count }`; frontend updates in place without full reload.
+5. Deleted messages are non-reactable and should render with no reaction controls; deletion removes stored reactions.
+
+## Decision locks (backend-coupled only)
+- [x] Locked: emoji set includes `👍 👎 ❤️ 😂 🔥 👀 🎉`.
+- [x] Locked: per-user model allows multiple different emojis on same message, one row per emoji.
+- [x] Locked: non-room-members cannot react.
+- [x] Locked: users can only remove their own reactions.
+- [x] Locked: deleted messages are non-reactable and render no reaction UI.
+- [x] Locked: deleting a message removes stored reactions.
+- [x] Locked: UI shows max 5 pills inline, then `+N`.
+- [x] Locked: pills sort by count desc with allowlist-order tie breaks.
+- [x] Locked: WS payload includes `room_id`, `message_id`, `emoji`, `user_id`, `count`.
+- [x] Locked: client is server-authoritative (no optimistic final-state assumptions).
+- [x] Locked: reaction endpoints are rate-limited at `40/minute`.
+- [x] Locked: backend/frontend tests for these constraints are listed before implementation.
+
+## Acceptance criteria
+- [ ] `message_reactions` table exists with required columns, constraints, and indexes.
+- [ ] `POST /api/messages/{message_id}/reactions` adds caller reaction for an allowlisted emoji.
+- [ ] `DELETE /api/messages/{message_id}/reactions/{emoji}` removes caller's own reaction only.
+- [ ] Reaction endpoints enforce room membership and deleted-message non-reactable policy.
+- [ ] Message payloads include reaction summary entries with `emoji`, `count`, `reacted_by_me`.
+- [ ] WS emits `reaction_added` and `reaction_removed` payloads with locked fields.
+- [ ] Frontend renders allowlist controls and reaction pills (max 5 + `+N`) with deterministic ordering.
+- [ ] Frontend applies API+WS reaction updates in place and remains server-authoritative.
+- [ ] Message deletion clears reaction data and deleted messages do not render reaction controls.
+- [ ] Backend/frontend tests cover authz, sorting, deleted-message guard, uniqueness, and realtime updates.
+- [ ] Required docs are updated for any schema/API/WS changes.
+
+## Verification
+```bash
+# Backend
+make backend-verify
+
+# Frontend
+cd frontend && npx tsc --noEmit
+cd frontend && npx eslint src/
+cd frontend && npm run build
+```
+
+## PR checklist
+- [ ] PR references this issue (`Closes #...`)
+- [ ] Docs updated if needed (`docs/ARCHITECTURE.md`, `docs/PATTERNS.md`, `docs/REVIEW_CHECKLIST.md`, `backend/TESTPLAN.md`, `docs/adr/`)
+- [ ] Tests added/updated where needed


### PR DESCRIPTION
## Summary
- implement Phase 3.5 message reactions end-to-end across backend, websocket, and frontend
- add `message_reactions` table + migration with uniqueness and indexing guarantees
- add reaction add/remove APIs with room-membership auth, deleted-message guardrails, and `40/min` rate limits
- include reaction summaries in message payloads and broadcast server-authoritative WS reaction delta events
- add frontend reaction handling and UX: `REACT` action button opens emoji submenu; pills remain sorted with max-5 + `+N`
- add/update backend and frontend tests and update architecture/test-plan docs

## Acceptance Criteria Check
- [x] `message_reactions` table exists with required columns, constraints, and indexes.
- [x] `POST /api/messages/{message_id}/reactions` adds caller reaction for an allowlisted emoji.
- [x] `DELETE /api/messages/{message_id}/reactions/{emoji}` removes caller's own reaction only.
- [x] Reaction endpoints enforce room membership and deleted-message non-reactable policy.
- [x] Message payloads include reaction summary entries with `emoji`, `count`, `reacted_by_me`.
- [x] WS emits `reaction_added` and `reaction_removed` payloads with locked fields.
- [x] Frontend renders allowlist controls and reaction pills (max 5 + `+N`) with deterministic ordering.
- [x] Frontend applies API+WS reaction updates in place and remains server-authoritative.
- [x] Message deletion clears reaction data and deleted messages do not render reaction controls.
- [x] Backend/frontend tests cover authz, sorting, deleted-message guard, uniqueness, and realtime updates.
- [x] Required docs are updated for schema/API/WS changes (`docs/ARCHITECTURE.md`, `backend/TESTPLAN.md`).

## Verification
- `make backend-verify SKIP_DB_BOOTSTRAP=1`
- `cd frontend && npx tsc --noEmit`
- `cd frontend && npx eslint src/`
- `cd frontend && npm run build`
- `cd frontend && npm test -- --run src/components/__tests__/MessageList.test.tsx src/components/__tests__/ChatLayout.test.tsx src/services/__tests__/api.test.ts`

Closes #32
