### PR TITLE
Task #34: Message row action shelf + long-press UX sweep

### DIFF
--- a/docs/PATTERNS.md
+++ b/docs/PATTERNS.md
@@ -71,6 +71,8 @@ Reusable code patterns and conventions in this project. All of the following are
 - **Portals:** Modals (create room, delete room) use `createPortal(..., document.body)` to render outside the sidebar DOM hierarchy.
 - **One WebSocket provider:** WebSocketProvider wraps ChatLayout; only chat page uses WebSocket. Auth state is above so token is available when mounting WebSocketProvider.
 - **Decomposition baseline for large frontend components:** Keep the top-level component as a composition container and extract state orchestration into `src/hooks/useXxx.ts` plus feature-scoped presentational components under `src/components/<feature-kebab>/` (for example: `RoomList` + `useRoomsData` + `components/room-list/*`).
+- **Input-modality action surfaces (message rows):** For mixed desktop/mobile controls, split interaction by pointer mode:
+  desktop uses one hover/focus `...` trigger that opens an anchored action shelf; coarse-pointer devices use long-press + bottom-sheet actions without persistent inline controls.
 
 ### Frontend Anti-Bloat Baseline
 

--- a/docs/specs/frontend-design-audit.md
+++ b/docs/specs/frontend-design-audit.md
@@ -679,7 +679,49 @@ Implementation Ready Checklist (3.6):
 - `Locked`: room update endpoint rate limit is set to `20/minute`.
 - `Locked`: backend/frontend tests for all above are listed in `backend/TESTPLAN.md` and frontend test plan before implementation starts.
 
-### 3.7 Parking Lot (Defer)
+### 3.7 Message Row Action UX Sweep ✅ Completed 2026-02-24
+**Value:** Medium-high.
+
+How it works:
+1. Desktop keeps hover/focus discoverability with a single `...` trigger.
+2. Desktop `...` opens an anchored action shelf for reactions/edit/delete.
+3. Mobile opens message actions with long-press only.
+3. Mobile action surface uses a bottom sheet for larger touch targets.
+
+Frontend plan:
+- Replace inline text action labels (`REACT`/`EDIT`/`DELETE`) with menu-driven actions.
+- Remove fixed-width layout reservation for hidden action controls.
+- Add long-press trigger (`350ms`) for coarse pointer devices.
+- Add desktop hover/focus `...` trigger that opens the same action set in an anchored shelf.
+- Add mobile bottom-sheet action menu with quick reactions + edit/delete actions.
+- Keep existing delete confirmation modal and permission logic unchanged.
+
+Files expected:
+- `frontend/src/components/message-list/MessageRow.tsx`
+- `frontend/src/components/__tests__/MessageList.test.tsx`
+
+Tests:
+- Frontend: desktop `...` trigger opens actions wired through existing handlers.
+- Frontend: long-press opens mobile action sheet.
+- Frontend: coarse-pointer mode does not render a fallback `...` trigger.
+- Frontend: action-sheet reaction toggles call existing reaction endpoints.
+
+Locked decisions for implementation (3.7):
+- Mobile action surface is a bottom sheet.
+- Long-press threshold is `350ms`.
+- Desktop uses one hover/focus `...` trigger that opens an anchored action shelf.
+- Mobile has no fallback `...` trigger (long-press only).
+- Keep deleted rows non-reactable/non-editable and without action entry points.
+
+Implementation Ready Checklist (3.7):
+- `Locked`: desktop renders one hover/focus `...` trigger and shelf controls with explicit `aria-label`s.
+- `Locked`: hidden desktop action controls do not reserve fixed message-row width.
+- `Locked`: coarse-pointer long-press opens bottom-sheet actions.
+- `Locked`: coarse-pointer mode removes the fallback `...` trigger to reduce visual noise.
+- `Locked`: existing backend/API/WS contracts remain unchanged.
+- `Locked`: frontend tests for desktop + mobile interaction paths are added before implementation starts.
+
+### 3.8 Parking Lot (Defer)
 - URL permalink/deep-link route support (separate from internal jump, higher complexity).
 - User bio/status profile expansion (lower immediate UX value vs cost).
 
@@ -697,6 +739,7 @@ Use this section as the implementation gate. Detailed lock rationale and accepta
 | `3.4` Message Deletion | `Locked` | `2026-02-24` | Owner + room creator; authz-first before idempotent `204`; soft delete + content scrub; `(deleted)` muted tombstone in place; excluded from search; WS uses existing `{ type, message }` envelope; rate limit `20/minute`. |
 | `3.5` Message Reactions | `Locked` | `2026-02-22` | Allowlist `👍 👎 ❤️ 😂 🔥 👀 🎉`; multi-emoji per user (one per emoji); member-only; no deleted-message reactions; max 5 pills + `+N`; server-authoritative; rate limit `40/minute`. |
 | `3.6` Room Descriptions | `Locked` | `2026-02-22` | Creator-only single room `PATCH` for name+description; plain text max `255`; trim/no newlines; empty clears to null; header+discovery surfaces; mobile truncate + `...`; server-authoritative; rate limit `20/minute`. |
+| `3.7` Message Row Action UX Sweep | `Locked` | `2026-02-24` | Desktop hover/focus `...` opens anchored action shelf; no fixed action-width reservation; mobile long-press (`350ms`) with no fallback button; bottom-sheet action menu; no backend/API/WS changes. |
 
 Lock maintenance rule:
 - If a lock changes, update both this matrix and the corresponding `Locked decisions` + `Implementation Ready Checklist` in the feature section.
@@ -715,7 +758,8 @@ Lock maintenance rule:
 9. Phase 3.4 deletion.
 10. Phase 3.5 reactions.
 11. Phase 3.6 room descriptions.
-12. Parking lot items only with explicit product demand.
+12. Phase 3.7 message row action UX sweep.
+13. Parking lot items only with explicit product demand.
 
 ---
 

--- a/frontend/src/components/__tests__/MessageList.test.tsx
+++ b/frontend/src/components/__tests__/MessageList.test.tsx
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import type { ComponentProps } from "react";
@@ -12,6 +12,7 @@ const mockEditMessage = vi.fn();
 const mockAddMessageReaction = vi.fn();
 const mockRemoveMessageReaction = vi.fn();
 const mockOnIncomingMessagesProcessed = vi.fn();
+const originalMatchMedia = window.matchMedia;
 
 vi.mock("../../context/AuthContext", () => ({
   useAuth: () => ({
@@ -74,6 +75,30 @@ function renderMessageList(overrides?: Partial<ComponentProps<typeof MessageList
   );
 }
 
+function mockPointerMode(coarsePointer: boolean) {
+  Object.defineProperty(window, "matchMedia", {
+    writable: true,
+    value: vi.fn().mockImplementation((query: string) => ({
+      matches: query === "(pointer: coarse)" ? coarsePointer : false,
+      media: query,
+      onchange: null,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    })),
+  });
+}
+
+async function longPressMessage(text: string) {
+  const content = await screen.findByText(text);
+  fireEvent.pointerDown(content, { pointerType: "touch", clientX: 80, clientY: 60 });
+  await act(async () => {
+    await new Promise((resolve) => setTimeout(resolve, 360));
+  });
+}
+
 function makeHistory(total: number, startId = 1): Message[] {
   const base = new Date("2024-01-01T10:00:00Z").getTime();
   return Array.from({ length: total }, (_, index) =>
@@ -95,6 +120,7 @@ function getUppercaseDateLabel(isoString: string): string {
 
 describe("MessageList", () => {
   beforeEach(() => {
+    mockPointerMode(false);
     mockGetRoomMessages.mockReset();
     mockGetRoomMessagesNewer.mockReset();
     mockDeleteMessage.mockReset();
@@ -123,6 +149,13 @@ describe("MessageList", () => {
       message_id: 1,
       room_id: 1,
       reactions: [],
+    });
+  });
+
+  afterAll(() => {
+    Object.defineProperty(window, "matchMedia", {
+      writable: true,
+      value: originalMatchMedia,
     });
   });
 
@@ -237,7 +270,7 @@ describe("MessageList", () => {
     expect(screen.queryByText("Original deleted content")).not.toBeInTheDocument();
   });
 
-  it("renders one reaction-menu trigger for active messages and hides it for deleted rows", async () => {
+  it("renders one message-actions trigger for active messages and hides it for deleted rows", async () => {
     const activeMessage = makeMessage({
       id: 8,
       username: "alice",
@@ -260,7 +293,7 @@ describe("MessageList", () => {
     renderMessageList();
     await screen.findByText("Active row");
 
-    const menuButtons = screen.getAllByRole("button", { name: "Open reaction menu" });
+    const menuButtons = screen.getAllByRole("button", { name: "More message actions" });
     expect(menuButtons).toHaveLength(1);
   });
 
@@ -292,17 +325,71 @@ describe("MessageList", () => {
     renderMessageList();
     await screen.findByText("Toggle reactions here");
 
-    await user.click(screen.getByRole("button", { name: "Open reaction menu" }));
+    await user.click(screen.getByRole("button", { name: "More message actions" }));
     await user.click(screen.getByRole("button", { name: "Add 👍 reaction" }));
     await waitFor(() => {
       expect(mockAddMessageReaction).toHaveBeenCalledWith(10, "👍", "test-token");
     });
     expect(screen.getByRole("button", { name: "Toggle 👍 reaction" })).toBeInTheDocument();
 
-    await user.click(screen.getByRole("button", { name: "Open reaction menu" }));
+    await user.click(screen.getByRole("button", { name: "More message actions" }));
     await user.click(screen.getByRole("button", { name: "Remove 👍 reaction" }));
     await waitFor(() => {
       expect(mockRemoveMessageReaction).toHaveBeenCalledWith(10, "👍", "test-token");
+    });
+  });
+
+  it("opens mobile message actions from long-press only", async () => {
+    mockPointerMode(true);
+    const user = userEvent.setup();
+    const message = makeMessage({
+      id: 11,
+      userId: 2,
+      username: "bob",
+      content: "Touch actions here",
+      createdAt: "2024-01-01T10:00:00Z",
+    });
+
+    mockGetRoomMessages.mockResolvedValueOnce({
+      messages: [message],
+      next_cursor: null,
+    });
+
+    renderMessageList();
+    await longPressMessage("Touch actions here");
+    expect(screen.getByRole("dialog", { name: "Message actions" })).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Close message actions" }));
+    expect(screen.queryByRole("dialog", { name: "Message actions" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "More message actions" })).not.toBeInTheDocument();
+  });
+
+  it("toggles reactions from the mobile action sheet", async () => {
+    mockPointerMode(true);
+    const user = userEvent.setup();
+    const message = makeMessage({
+      id: 12,
+      userId: 2,
+      username: "bob",
+      content: "Sheet reactions",
+      createdAt: "2024-01-01T10:00:00Z",
+    });
+
+    mockGetRoomMessages.mockResolvedValueOnce({
+      messages: [message],
+      next_cursor: null,
+    });
+    mockAddMessageReaction.mockResolvedValueOnce({
+      message_id: 12,
+      room_id: 1,
+      reactions: [{ emoji: "👍", count: 1, reacted_by_me: true }],
+    });
+
+    renderMessageList();
+    await longPressMessage("Sheet reactions");
+    await user.click(screen.getByRole("button", { name: "Add 👍 reaction" }));
+    await waitFor(() => {
+      expect(mockAddMessageReaction).toHaveBeenCalledWith(12, "👍", "test-token");
     });
   });
 
@@ -463,6 +550,7 @@ describe("MessageList", () => {
     renderMessageList();
     await screen.findByText("Delete me");
 
+    await user.click(screen.getByRole("button", { name: "More message actions" }));
     await user.click(screen.getByRole("button", { name: "Delete message" }));
     expect(screen.getByRole("dialog")).toBeInTheDocument();
     expect(screen.getByText("Delete Message?")).toBeInTheDocument();
@@ -489,6 +577,7 @@ describe("MessageList", () => {
     renderMessageList();
     await screen.findByText("Cancel delete");
 
+    await user.click(screen.getByRole("button", { name: "More message actions" }));
     await user.click(screen.getByRole("button", { name: "Delete message" }));
     expect(screen.getByRole("dialog")).toBeInTheDocument();
     await user.click(screen.getByRole("button", { name: "CANCEL" }));
@@ -552,6 +641,7 @@ describe("MessageList", () => {
     renderMessageList();
     await screen.findByText("Original content");
 
+    await user.click(screen.getByRole("button", { name: "More message actions" }));
     await user.click(screen.getByRole("button", { name: "Edit message" }));
     const textarea = screen.getByLabelText("Edit message content");
     await user.clear(textarea);
@@ -592,6 +682,7 @@ describe("MessageList", () => {
     renderMessageList();
     await screen.findByText("Line one");
 
+    await user.click(screen.getByRole("button", { name: "More message actions" }));
     await user.click(screen.getByRole("button", { name: "Edit message" }));
     const textarea = screen.getByLabelText("Edit message content");
     await user.click(textarea);
@@ -610,6 +701,7 @@ describe("MessageList", () => {
     expect(updatedRow).not.toBeNull();
     expect(updatedRow).toHaveTextContent("Line one Line two");
 
+    await user.click(screen.getByRole("button", { name: "More message actions" }));
     await user.click(screen.getByRole("button", { name: "Edit message" }));
     const reopened = screen.getByLabelText("Edit message content");
     fireEvent.keyDown(reopened, { key: "Escape" });

--- a/frontend/src/components/message-list/MessageRow.tsx
+++ b/frontend/src/components/message-list/MessageRow.tsx
@@ -1,7 +1,17 @@
-import { useEffect, useRef, useState, type KeyboardEvent } from "react";
+import {
+  useEffect,
+  useRef,
+  useState,
+  type KeyboardEvent,
+  type PointerEvent as ReactPointerEvent,
+} from "react";
+import { Ellipsis } from "lucide-react";
 import { getUserColorPalette } from "../../utils/userColors";
 import type { Message, ReactionEmoji } from "../../types";
 import { REACTION_ALLOWLIST, sortReactions } from "./reactionConfig";
+
+const LONG_PRESS_MS = 350;
+const LONG_PRESS_MOVE_THRESHOLD = 10;
 
 interface MessageRowProps {
   message: Message;
@@ -30,6 +40,16 @@ interface MessageRowProps {
   onSaveEdit: () => void;
   onDeleteMessage: (messageId: number) => void;
   onToggleReaction: (messageId: number, emoji: ReactionEmoji, reactedByMe: boolean) => void;
+}
+
+function isInteractiveTarget(target: EventTarget | null): boolean {
+  if (!(target instanceof HTMLElement)) return false;
+
+  return Boolean(
+    target.closest(
+      "button, a, input, textarea, select, [role='button'], [contenteditable='true']",
+    ),
+  );
 }
 
 export function MessageRow({
@@ -68,9 +88,21 @@ export function MessageRow({
   const visibleReactions = reactions.slice(0, 5);
   const overflowReactionsCount = Math.max(0, reactions.length - visibleReactions.length);
   const editTextareaRef = useRef<HTMLTextAreaElement | null>(null);
-  const [reactionMenuOpen, setReactionMenuOpen] = useState(false);
+  const actionTriggerRef = useRef<HTMLButtonElement | null>(null);
+  const longPressTimerRef = useRef<number | null>(null);
+  const longPressOriginRef = useRef<{ x: number; y: number } | null>(null);
+
+  const [actionMenuOpen, setActionMenuOpen] = useState(false);
+  const [isCoarsePointer, setIsCoarsePointer] = useState(false);
+  const [desktopShelfPlacement, setDesktopShelfPlacement] = useState<"below" | "above">(
+    "below",
+  );
 
   const getReactionKey = (emoji: ReactionEmoji): string => `${message.id}:${emoji}`;
+  const hasActionControls = !isEditing && !isDeleted && (canEdit || canDelete || canReact);
+  const actionMenuVisible = actionMenuOpen && hasActionControls;
+  const mobileActionSheetVisible = actionMenuVisible && isCoarsePointer;
+  const desktopActionShelfVisible = actionMenuVisible && !isCoarsePointer;
 
   useEffect(() => {
     if (!isEditing) return;
@@ -83,325 +115,528 @@ export function MessageRow({
     textarea.setSelectionRange(cursorAtEnd, cursorAtEnd);
   }, [isEditing]);
 
-  const reactionMenuVisible = reactionMenuOpen && !isEditing && !isDeleted;
+  useEffect(() => {
+    if (typeof window === "undefined" || typeof window.matchMedia !== "function") {
+      return;
+    }
+
+    const coarsePointerQuery = window.matchMedia("(pointer: coarse)");
+    const updatePointerMode = () => {
+      setIsCoarsePointer(coarsePointerQuery.matches);
+    };
+
+    updatePointerMode();
+
+    coarsePointerQuery.addEventListener("change", updatePointerMode);
+    return () => {
+      coarsePointerQuery.removeEventListener("change", updatePointerMode);
+    };
+  }, []);
+
+  const clearLongPressTimer = () => {
+    if (longPressTimerRef.current == null) return;
+
+    window.clearTimeout(longPressTimerRef.current);
+    longPressTimerRef.current = null;
+    longPressOriginRef.current = null;
+  };
+
+  useEffect(() => clearLongPressTimer, []);
+
+  useEffect(() => {
+    if (!actionMenuVisible) return;
+
+    const handleEscape = (event: globalThis.KeyboardEvent) => {
+      if (event.key !== "Escape") return;
+      setActionMenuOpen(false);
+    };
+
+    window.addEventListener("keydown", handleEscape);
+    return () => {
+      window.removeEventListener("keydown", handleEscape);
+    };
+  }, [actionMenuVisible]);
+
+  const closeActionMenu = () => {
+    setActionMenuOpen(false);
+  };
+
+  const handleLongPressPointerDown = (event: ReactPointerEvent<HTMLDivElement>) => {
+    if (!isCoarsePointer || !hasActionControls) return;
+    if (event.pointerType === "mouse") return;
+    if (isInteractiveTarget(event.target)) return;
+
+    clearLongPressTimer();
+    longPressOriginRef.current = { x: event.clientX, y: event.clientY };
+
+    longPressTimerRef.current = window.setTimeout(() => {
+      setActionMenuOpen(true);
+      longPressTimerRef.current = null;
+      longPressOriginRef.current = null;
+    }, LONG_PRESS_MS);
+  };
+
+  const handleLongPressPointerMove = (event: ReactPointerEvent<HTMLDivElement>) => {
+    if (longPressTimerRef.current == null || longPressOriginRef.current == null) return;
+
+    const deltaX = Math.abs(event.clientX - longPressOriginRef.current.x);
+    const deltaY = Math.abs(event.clientY - longPressOriginRef.current.y);
+
+    // Let users scroll naturally without accidentally triggering the long-press action sheet.
+    if (deltaX > LONG_PRESS_MOVE_THRESHOLD || deltaY > LONG_PRESS_MOVE_THRESHOLD) {
+      clearLongPressTimer();
+    }
+  };
+
+  const handleLongPressCancel = () => {
+    clearLongPressTimer();
+  };
+
+  const handleReactionSelection = (emoji: ReactionEmoji, reactedByMe: boolean) => {
+    onToggleReaction(message.id, emoji, reactedByMe);
+    closeActionMenu();
+  };
+
+  const handleStartEdit = () => {
+    onStartEdit(message.id, message.content);
+    closeActionMenu();
+  };
+
+  const handleDelete = () => {
+    onDeleteMessage(message.id);
+    closeActionMenu();
+  };
+
+  const resolveDesktopShelfPlacement = () => {
+    const trigger = actionTriggerRef.current;
+    if (!trigger) return;
+
+    const triggerRect = trigger.getBoundingClientRect();
+    const estimatedShelfHeight = 280;
+    const spaceBelow = window.innerHeight - triggerRect.bottom;
+    const spaceAbove = triggerRect.top;
+
+    if (spaceBelow < estimatedShelfHeight && spaceAbove > spaceBelow) {
+      setDesktopShelfPlacement("above");
+      return;
+    }
+
+    setDesktopShelfPlacement("below");
+  };
+
+  const actionTriggerClass =
+    "h-8 w-8 flex items-center justify-center border transition-colors opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 focus-visible:opacity-100 focus-visible:outline focus-visible:outline-1";
+
+  const quickReactionButtons = (
+    <div className="flex items-center gap-1 flex-nowrap">
+      {REACTION_ALLOWLIST.map((emoji) => {
+        const matchingReaction = reactions.find((reaction) => reaction.emoji === emoji);
+        const reactedByMe = matchingReaction?.reacted_by_me ?? false;
+        const reactionPending = pendingReactionKeys.includes(getReactionKey(emoji));
+
+        return (
+          <button
+            key={emoji}
+            type="button"
+            disabled={reactionPending}
+            onClick={() => handleReactionSelection(emoji, reactedByMe)}
+            className="h-8 w-8 shrink-0 font-mono text-[14px] border"
+            style={{
+              color: reactedByMe ? "var(--color-primary)" : "var(--color-text)",
+              borderColor: reactedByMe ? "var(--color-primary)" : "var(--border-dim)",
+              background: reactedByMe
+                ? "color-mix(in srgb, var(--color-primary) 10%, transparent)"
+                : "transparent",
+              opacity: reactionPending ? 0.55 : 1,
+            }}
+            aria-label={reactedByMe ? `Remove ${emoji} reaction` : `Add ${emoji} reaction`}
+          >
+            {emoji}
+          </button>
+        );
+      })}
+    </div>
+  );
+
+  const actionMenuContent = (
+    <>
+      <p
+        className="font-pixel text-[8px] tracking-[0.16em] mb-2"
+        style={{ color: "var(--color-text)" }}
+      >
+        MESSAGE ACTIONS
+      </p>
+
+      {canReact && (
+        <div className="mb-3">
+          <p
+            className="font-mono text-[11px] mb-1"
+            style={{ color: "var(--color-text)" }}
+          >
+            Quick reactions
+          </p>
+          {quickReactionButtons}
+        </div>
+      )}
+
+      <div className="flex flex-col gap-2">
+        {canEdit && (
+          <button
+            type="button"
+            onClick={handleStartEdit}
+            className="w-full min-h-10 font-mono text-[12px] tracking-[0.08em] px-3 py-2 border text-left"
+            style={{
+              color: "var(--color-text)",
+              borderColor: "var(--border-dim)",
+              background: "transparent",
+            }}
+            aria-label="Edit message"
+          >
+            EDIT MESSAGE
+          </button>
+        )}
+        {canDelete && (
+          <button
+            type="button"
+            onClick={handleDelete}
+            disabled={isDeleting}
+            className="w-full min-h-10 font-mono text-[12px] tracking-[0.08em] px-3 py-2 border text-left"
+            style={{
+              color: "var(--color-text)",
+              borderColor: "rgba(255, 68, 68, 0.35)",
+              background: "transparent",
+              opacity: isDeleting ? 0.55 : 1,
+            }}
+            aria-label={isDeleting ? "Deleting message" : "Delete message"}
+          >
+            {isDeleting ? "DELETING MESSAGE" : "DELETE MESSAGE"}
+          </button>
+        )}
+        <button
+          type="button"
+          onClick={closeActionMenu}
+          className="w-full min-h-10 font-mono text-[12px] tracking-[0.08em] px-3 py-2 border text-left"
+          style={{
+            color: "var(--color-text)",
+            borderColor: "var(--border-dim)",
+            background: "transparent",
+          }}
+          aria-label="Cancel message actions"
+        >
+          CANCEL
+        </button>
+      </div>
+    </>
+  );
 
   return (
-    <div
-      data-chat-message="true"
-      data-message-id={message.id}
-      className={`group flex items-start hover:bg-white/[0.02] transition-colors ${
-        isComfortableDensity ? "gap-3 px-2" : "gap-2.5 px-1.5"
-      } ${
-        isGrouped
-          ? isComfortableDensity
-            ? "mt-0.5 py-0.5"
-            : "mt-0 py-0.5"
-          : isComfortableDensity
-            ? "mt-3.5 py-0.5"
-            : "mt-2.5 py-0.5"
-      }`}
-      style={{
-        animation: "slide-in 0.2s ease-out",
-        background: isHighlighted ? "rgba(0, 240, 255, 0.10)" : undefined,
-        borderLeft: isHighlighted
-          ? "2px solid var(--color-primary)"
-          : "2px solid transparent",
-      }}
-    >
+    <>
       <div
-        className={`shrink-0 select-none flex justify-center ${
-          isComfortableDensity ? "w-11" : "w-9"
+        data-chat-message="true"
+        data-message-id={message.id}
+        className={`group flex items-start hover:bg-white/[0.02] transition-colors ${
+          isComfortableDensity ? "gap-3 px-2" : "gap-2.5 px-1.5"
+        } ${
+          isGrouped
+            ? isComfortableDensity
+              ? "mt-0.5 py-0.5"
+              : "mt-0 py-0.5"
+            : isComfortableDensity
+              ? "mt-3.5 py-0.5"
+              : "mt-2.5 py-0.5"
         }`}
+        style={{
+          animation: "slide-in 0.2s ease-out",
+          background: isHighlighted ? "rgba(0, 240, 255, 0.10)" : undefined,
+          borderLeft: isHighlighted
+            ? "2px solid var(--color-primary)"
+            : "2px solid transparent",
+        }}
       >
-        {!isGrouped ? (
-          <div
-            className={`rounded-full flex items-center justify-center font-bebas ${
-              isComfortableDensity ? "w-11 h-11 text-[16px]" : "w-9 h-9 text-[14px]"
-            }`}
-            style={{
-              background: userColors?.backgroundColor ?? "var(--bg-app)",
-              border: `1px solid ${userColors?.borderColor ?? "var(--border-primary)"}`,
-              color: userColors?.textColor ?? "var(--color-primary)",
-              boxShadow: userColors?.glowColor ?? "none",
-            }}
-          >
-            {message.username.substring(0, 2).toUpperCase()}
-          </div>
-        ) : (
-          <span
-            className={`block font-mono pt-1 text-center w-full whitespace-nowrap opacity-0 group-hover:opacity-100 transition-opacity duration-150 ${
-              isComfortableDensity ? "text-[12px]" : "text-[11px]"
-            }`}
-            style={{ color: "var(--color-meta)" }}
-            title={fullDateTime}
-          >
-            {hoverTime}
-          </span>
-        )}
-      </div>
-
-      <div className="flex flex-col min-w-0 flex-1">
-        {!isGrouped && (
-          <div className="flex items-baseline gap-2">
-            <span
-              className="font-mono font-semibold text-[14px] tracking-[0.06em]"
-              style={{ color: userColors?.textColor ?? "var(--color-primary)" }}
+        <div
+          className={`shrink-0 select-none flex justify-center ${
+            isComfortableDensity ? "w-11" : "w-9"
+          }`}
+        >
+          {!isGrouped ? (
+            <div
+              className={`rounded-full flex items-center justify-center font-bebas ${
+                isComfortableDensity ? "w-11 h-11 text-[16px]" : "w-9 h-9 text-[14px]"
+              }`}
+              style={{
+                background: userColors?.backgroundColor ?? "var(--bg-app)",
+                border: `1px solid ${userColors?.borderColor ?? "var(--border-primary)"}`,
+                color: userColors?.textColor ?? "var(--color-primary)",
+                boxShadow: userColors?.glowColor ?? "none",
+              }}
             >
-              {message.username}
-            </span>
+              {message.username.substring(0, 2).toUpperCase()}
+            </div>
+          ) : (
             <span
-              className={`font-mono tracking-[0.08em] ${
+              className={`block font-mono pt-1 text-center w-full whitespace-nowrap opacity-0 group-hover:opacity-100 transition-opacity duration-150 ${
                 isComfortableDensity ? "text-[12px]" : "text-[11px]"
               }`}
               style={{ color: "var(--color-meta)" }}
               title={fullDateTime}
             >
-              {headerTime}
+              {hoverTime}
             </span>
-            {isEdited && !isEditing && (
+          )}
+        </div>
+
+        <div className="flex flex-col min-w-0 flex-1">
+          {!isGrouped && (
+            <div className="flex items-baseline gap-2">
               <span
-                className="font-mono text-[10px] tracking-[0.08em]"
-                style={{ color: "var(--color-meta)" }}
-                title={editedFullDateTime}
-                aria-label={`Edited at ${editedHoverTime}`}
+                className="font-mono font-semibold text-[14px] tracking-[0.06em]"
+                style={{ color: userColors?.textColor ?? "var(--color-primary)" }}
               >
-                (edited)
+                {message.username}
               </span>
-            )}
-          </div>
-        )}
-
-        <div className="flex items-start justify-between gap-3">
-          <div className="min-w-0 flex-1">
-            {isEditing ? (
-              <div className={`${isGrouped ? "" : isComfortableDensity ? "mt-1" : "mt-0.5"}`}>
-                <textarea
-                  ref={editTextareaRef}
-                  value={editDraft}
-                  onChange={(event) => onEditDraftChange(event.target.value)}
-                  onKeyDown={onEditKeyDown}
-                  className="w-full resize-none font-mono text-[14px] leading-normal px-2 py-1 border rounded-none"
-                  style={{
-                    color: "var(--color-msg-text)",
-                    background: "var(--bg-panel)",
-                    borderColor: "var(--border-dim)",
-                  }}
-                  rows={Math.max(2, editDraft.split("\n").length)}
-                  aria-label="Edit message content"
-                />
-                {editError && (
-                  <p
-                    className="mt-1 font-mono text-[11px]"
-                    style={{ color: "#ff4444" }}
-                    role="alert"
-                  >
-                    {editError}
-                  </p>
-                )}
-                <div className="mt-2 flex items-center gap-2">
-                  <button
-                    type="button"
-                    onClick={onSaveEdit}
-                    disabled={isSavingEdit}
-                    className="font-mono text-[10px] tracking-[0.08em] px-2 py-1 border"
-                    style={{
-                      color: "var(--color-meta)",
-                      borderColor: "var(--border-dim)",
-                      background: "transparent",
-                    }}
-                    aria-label={isSavingEdit ? "Saving edit" : "Save message edit"}
-                  >
-                    {isSavingEdit ? "SAVING" : "SAVE"}
-                  </button>
-                  <button
-                    type="button"
-                    onClick={onCancelEdit}
-                    disabled={isSavingEdit}
-                    className="font-mono text-[10px] tracking-[0.08em] px-2 py-1 border"
-                    style={{
-                      color: "var(--color-meta)",
-                      borderColor: "var(--border-dim)",
-                      background: "transparent",
-                    }}
-                    aria-label="Cancel message edit"
-                  >
-                    CANCEL
-                  </button>
-                </div>
-              </div>
-            ) : (
-              <>
-                <div
-                  className={`font-mono break-words ${
-                    isDeleted
-                      ? isComfortableDensity
-                        ? "text-[13px] leading-normal"
-                        : "text-[12px] leading-normal"
-                      : isComfortableDensity
-                        ? "text-[18px] leading-relaxed"
-                        : "text-[15px] leading-normal"
-                  } ${isGrouped ? "" : isComfortableDensity ? "mt-1" : "mt-0.5"}`}
-                  style={{ color: isDeleted ? "var(--color-meta)" : "var(--color-msg-text)" }}
+              <span
+                className={`font-mono tracking-[0.08em] ${
+                  isComfortableDensity ? "text-[12px]" : "text-[11px]"
+                }`}
+                style={{ color: "var(--color-meta)" }}
+                title={fullDateTime}
+              >
+                {headerTime}
+              </span>
+              {isEdited && !isEditing && (
+                <span
+                  className="font-mono text-[10px] tracking-[0.08em]"
+                  style={{ color: "var(--color-meta)" }}
+                  title={editedFullDateTime}
+                  aria-label={`Edited at ${editedHoverTime}`}
                 >
-                  {isDeleted ? "(deleted)" : message.content}
-                </div>
-                {isGrouped && isEdited && (
-                  <span
-                    className="mt-0.5 inline-block font-mono text-[10px] tracking-[0.08em]"
-                    style={{ color: "var(--color-meta)" }}
-                    title={editedFullDateTime}
-                    aria-label={`Edited at ${editedHoverTime}`}
-                  >
-                    (edited)
-                  </span>
-                )}
-                {reactions.length > 0 && (
-                  <div className="mt-2 flex items-center gap-1 flex-wrap">
-                    {visibleReactions.map((reaction) => (
-                      <button
-                        key={reaction.emoji}
-                        type="button"
-                        disabled={pendingReactionKeys.includes(getReactionKey(reaction.emoji))}
-                        onClick={() =>
-                          onToggleReaction(
-                            message.id,
-                            reaction.emoji,
-                            reaction.reacted_by_me,
-                          )
-                        }
-                        className="font-mono text-[10px] px-2 py-0.5 border transition-colors"
-                        style={{
-                          color: reaction.reacted_by_me
-                            ? "var(--color-primary)"
-                            : "var(--color-meta)",
-                          borderColor: reaction.reacted_by_me
-                            ? "var(--color-primary)"
-                            : "var(--border-dim)",
-                          background: reaction.reacted_by_me
-                            ? "color-mix(in srgb, var(--color-primary) 10%, transparent)"
-                            : "transparent",
-                        }}
-                        aria-label={`Toggle ${reaction.emoji} reaction`}
-                      >
-                        {reaction.emoji} {reaction.count}
-                      </button>
-                    ))}
-                    {overflowReactionsCount > 0 && (
-                      <span
-                        className="font-mono text-[10px] px-2 py-0.5 border"
-                        style={{
-                          color: "var(--color-meta)",
-                          borderColor: "var(--border-dim)",
-                        }}
-                        aria-label={`${overflowReactionsCount} more reactions`}
-                      >
-                        +{overflowReactionsCount}
-                      </span>
-                    )}
-                  </div>
-                )}
-              </>
-            )}
-          </div>
-          {!isEditing && (canEdit || canDelete || canReact) && (
-            <div className="relative flex items-center gap-1 opacity-0 group-hover:opacity-100 transition-opacity shrink-0">
-              {canReact && (
-                <>
-                  <button
-                    type="button"
-                    onClick={() => setReactionMenuOpen((prev) => !prev)}
-                    className="font-mono text-[10px] tracking-[0.08em] px-2 py-1 border"
-                    style={{
-                      color: "var(--color-meta)",
-                      borderColor: "var(--border-dim)",
-                      background: "transparent",
-                    }}
-                    aria-label={reactionMenuVisible ? "Close reaction menu" : "Open reaction menu"}
-                  >
-                    REACT
-                  </button>
-                  {reactionMenuVisible && (
-                    <div
-                      className="absolute right-0 top-full mt-1 z-10 p-1.5 border flex items-center gap-1"
-                      style={{
-                        background: "var(--bg-panel)",
-                        borderColor: "var(--border-dim)",
-                      }}
-                    >
-                      {REACTION_ALLOWLIST.map((emoji) => {
-                        const matchingReaction = reactions.find(
-                          (reaction) => reaction.emoji === emoji,
-                        );
-                        const reactedByMe = matchingReaction?.reacted_by_me ?? false;
-                        const reactionPending = pendingReactionKeys.includes(getReactionKey(emoji));
+                  (edited)
+                </span>
+              )}
+            </div>
+          )}
 
-                        return (
-                          <button
-                            key={emoji}
-                            type="button"
-                            disabled={reactionPending}
-                            onClick={() => {
-                              onToggleReaction(message.id, emoji, reactedByMe);
-                              setReactionMenuOpen(false);
-                            }}
-                            className="font-mono text-[12px] px-1.5 py-0.5 border transition-colors"
-                            style={{
-                              color: reactedByMe ? "var(--color-primary)" : "var(--color-meta)",
-                              borderColor: reactedByMe
-                                ? "var(--color-primary)"
-                                : "var(--border-dim)",
-                              background: reactedByMe
-                                ? "color-mix(in srgb, var(--color-primary) 10%, transparent)"
-                                : "transparent",
-                              opacity: reactionPending ? 0.55 : 1,
-                            }}
-                            aria-label={
-                              reactedByMe ? `Remove ${emoji} reaction` : `Add ${emoji} reaction`
-                            }
-                          >
-                            {emoji}
-                          </button>
-                        );
-                      })}
+          <div className="relative min-w-0 flex-1">
+            <div
+              className="min-w-0"
+              onPointerDown={isEditing ? undefined : handleLongPressPointerDown}
+              onPointerMove={isEditing ? undefined : handleLongPressPointerMove}
+              onPointerUp={isEditing ? undefined : handleLongPressCancel}
+              onPointerCancel={isEditing ? undefined : handleLongPressCancel}
+              onPointerLeave={isEditing ? undefined : handleLongPressCancel}
+            >
+              {isEditing ? (
+                <div className={`${isGrouped ? "" : isComfortableDensity ? "mt-1" : "mt-0.5"}`}>
+                  <textarea
+                    ref={editTextareaRef}
+                    value={editDraft}
+                    onChange={(event) => onEditDraftChange(event.target.value)}
+                    onKeyDown={onEditKeyDown}
+                    className="w-full resize-none font-mono text-[14px] leading-normal px-2 py-1 border rounded-none"
+                    style={{
+                      color: "var(--color-msg-text)",
+                      background: "var(--bg-panel)",
+                      borderColor: "var(--border-dim)",
+                    }}
+                    rows={Math.max(2, editDraft.split("\n").length)}
+                    aria-label="Edit message content"
+                  />
+                  {editError && (
+                    <p
+                      className="mt-1 font-mono text-[11px]"
+                      style={{ color: "#ff4444" }}
+                      role="alert"
+                    >
+                      {editError}
+                    </p>
+                  )}
+                  <div className="mt-2 flex items-center gap-2">
+                    <button
+                      type="button"
+                      onClick={onSaveEdit}
+                      disabled={isSavingEdit}
+                      className="font-mono text-[10px] tracking-[0.08em] px-2 py-1 border"
+                      style={{
+                        color: "var(--color-meta)",
+                        borderColor: "var(--border-dim)",
+                        background: "transparent",
+                      }}
+                      aria-label={isSavingEdit ? "Saving edit" : "Save message edit"}
+                    >
+                      {isSavingEdit ? "SAVING" : "SAVE"}
+                    </button>
+                    <button
+                      type="button"
+                      onClick={onCancelEdit}
+                      disabled={isSavingEdit}
+                      className="font-mono text-[10px] tracking-[0.08em] px-2 py-1 border"
+                      style={{
+                        color: "var(--color-meta)",
+                        borderColor: "var(--border-dim)",
+                        background: "transparent",
+                      }}
+                      aria-label="Cancel message edit"
+                    >
+                      CANCEL
+                    </button>
+                  </div>
+                </div>
+              ) : (
+                <>
+                  <div
+                    className={`font-mono break-words ${
+                      isDeleted
+                        ? isComfortableDensity
+                          ? "text-[13px] leading-normal"
+                          : "text-[12px] leading-normal"
+                        : isComfortableDensity
+                          ? "text-[18px] leading-relaxed"
+                          : "text-[15px] leading-normal"
+                    } ${isGrouped ? "" : isComfortableDensity ? "mt-1" : "mt-0.5"}`}
+                    style={{ color: isDeleted ? "var(--color-meta)" : "var(--color-msg-text)" }}
+                  >
+                    {isDeleted ? "(deleted)" : message.content}
+                  </div>
+                  {isGrouped && isEdited && (
+                    <span
+                      className="mt-0.5 inline-block font-mono text-[10px] tracking-[0.08em]"
+                      style={{ color: "var(--color-meta)" }}
+                      title={editedFullDateTime}
+                      aria-label={`Edited at ${editedHoverTime}`}
+                    >
+                      (edited)
+                    </span>
+                  )}
+                  {reactions.length > 0 && (
+                    <div className="mt-2 flex items-center gap-1 flex-wrap">
+                      {visibleReactions.map((reaction) => (
+                        <button
+                          key={reaction.emoji}
+                          type="button"
+                          disabled={pendingReactionKeys.includes(getReactionKey(reaction.emoji))}
+                          onClick={() =>
+                            onToggleReaction(
+                              message.id,
+                              reaction.emoji,
+                              reaction.reacted_by_me,
+                            )
+                          }
+                          className="font-mono text-[10px] px-2 py-0.5 border transition-colors"
+                          style={{
+                            color: reaction.reacted_by_me
+                              ? "var(--color-primary)"
+                              : "var(--color-meta)",
+                            borderColor: reaction.reacted_by_me
+                              ? "var(--color-primary)"
+                              : "var(--border-dim)",
+                            background: reaction.reacted_by_me
+                              ? "color-mix(in srgb, var(--color-primary) 10%, transparent)"
+                              : "transparent",
+                          }}
+                          aria-label={`Toggle ${reaction.emoji} reaction`}
+                        >
+                          {reaction.emoji} {reaction.count}
+                        </button>
+                      ))}
+                      {overflowReactionsCount > 0 && (
+                        <span
+                          className="font-mono text-[10px] px-2 py-0.5 border"
+                          style={{
+                            color: "var(--color-meta)",
+                            borderColor: "var(--border-dim)",
+                          }}
+                          aria-label={`${overflowReactionsCount} more reactions`}
+                        >
+                          +{overflowReactionsCount}
+                        </span>
+                      )}
                     </div>
                   )}
                 </>
               )}
-              {canEdit && (
-                <button
-                  type="button"
-                  onClick={() => onStartEdit(message.id, message.content)}
-                  className="font-mono text-[10px] tracking-[0.08em] px-2 py-1 border"
-                  style={{
-                    color: "var(--color-meta)",
-                    borderColor: "var(--border-dim)",
-                    background: "transparent",
-                  }}
-                  aria-label="Edit message"
-                >
-                  EDIT
-                </button>
-              )}
-              {canDelete && (
-                <button
-                  type="button"
-                  onClick={() => onDeleteMessage(message.id)}
-                  disabled={isDeleting}
-                  className="font-mono text-[10px] tracking-[0.08em] px-2 py-1 border"
-                  style={{
-                    color: "var(--color-meta)",
-                    borderColor: "rgba(255, 68, 68, 0.35)",
-                    background: "transparent",
-                  }}
-                  aria-label={isDeleting ? "Deleting message" : "Delete message"}
-                >
-                  {isDeleting ? "DELETING" : "DELETE"}
-                </button>
-              )}
             </div>
-          )}
+
+            {!isCoarsePointer && hasActionControls && (
+              <div className="absolute right-0 top-0 z-10">
+                <button
+                  ref={actionTriggerRef}
+                  type="button"
+                  onClick={() => {
+                    if (!actionMenuOpen) {
+                      resolveDesktopShelfPlacement();
+                    }
+                    setActionMenuOpen((prev) => !prev);
+                  }}
+                  className={actionTriggerClass}
+                  style={{
+                    color: "var(--color-text)",
+                    borderColor: "var(--border-dim)",
+                    background: "var(--bg-panel)",
+                  }}
+                  aria-label={desktopActionShelfVisible ? "Close message actions" : "More message actions"}
+                  title="Message actions"
+                >
+                  <Ellipsis size={14} aria-hidden="true" />
+                </button>
+              </div>
+            )}
+
+            {desktopActionShelfVisible && (
+              <>
+                <button
+                  type="button"
+                  className="fixed inset-0 z-20"
+                  style={{ background: "transparent" }}
+                  onClick={closeActionMenu}
+                  aria-label="Close message actions"
+                />
+                <div
+                  role="dialog"
+                  aria-label="Message actions"
+                  className={`absolute right-0 z-30 w-[17rem] border p-2 ${
+                    desktopActionShelfVisible && desktopShelfPlacement === "above"
+                      ? "bottom-9"
+                      : "top-9"
+                  }`}
+                  style={{
+                    background: "var(--bg-panel)",
+                    borderColor: "var(--border-dim)",
+                    boxShadow: "0 8px 24px rgba(0, 0, 0, 0.35)",
+                    maxHeight: "min(18rem, calc(100vh - 1rem))",
+                    overflowY: "auto",
+                  }}
+                >
+                  {actionMenuContent}
+                </div>
+              </>
+            )}
+          </div>
         </div>
       </div>
-    </div>
+
+      {mobileActionSheetVisible && (
+        <>
+          <button
+            type="button"
+            className="fixed inset-0 z-40"
+            style={{ background: "rgba(0, 0, 0, 0.65)" }}
+            onClick={closeActionMenu}
+            aria-label="Close message actions"
+          />
+          <div
+            role="dialog"
+            aria-label="Message actions"
+            className="fixed inset-x-0 bottom-0 z-50 border-t px-3 pb-4 pt-3"
+            style={{
+              background: "var(--bg-panel)",
+              borderColor: "var(--border-dim)",
+              boxShadow: "0 -8px 24px rgba(0, 0, 0, 0.35)",
+            }}
+          >
+            {actionMenuContent}
+          </div>
+        </>
+      )}
+    </>
   );
 }

--- a/plans/message-row-action-ux-sweep-whiteboard.md
+++ b/plans/message-row-action-ux-sweep-whiteboard.md
@@ -1,0 +1,97 @@
+## Goal
+Improve message-row action usability for `react/edit/delete` across desktop and mobile without changing backend/API/WS contracts.
+
+## Proposed Execution Mode
+`single` (default): one Task issue -> one PR.
+
+Why not `fast`: this touches interaction model, accessibility behavior, and tests across multiple frontend files.
+
+## Problem Statement
+- Current actions rely on hover visibility, which is poor on touch devices.
+- Action cluster occupies fixed horizontal space even when hidden (`opacity` only), reducing message content room.
+- Text buttons (`REACT/EDIT/DELETE`) are visually noisy and slower to scan than icon affordances.
+
+## UX Objectives
+- Remove fixed reserved action width from message rows.
+- Keep desktop hover/focus discoverability.
+- Add mobile-first long-press action entry.
+- Preserve existing permissions and safety constraints (deleted rows non-reactable/non-editable).
+- Keep retro theme language while improving clarity and hit targets.
+
+## Proposed Interaction Model
+### Desktop (`pointer: fine`, hover-capable)
+- Show a single `...` trigger on `group-hover` and `focus-within`.
+- Clicking `...` opens an anchored action shelf with quick reactions + edit/delete actions.
+- Shelf text and labels use brighter readability tokens (not muted meta text).
+
+### Mobile/Touch (`pointer: coarse`, no reliable hover)
+- Long-press on message body opens a message action menu.
+- Recommended surface: bottom sheet style menu (larger tap targets, thumb-friendly).
+- Menu sections:
+- Quick reactions row (locked allowlist)
+- `Edit message` action (only when allowed)
+- `Delete message` action (only when allowed)
+- `Cancel`
+- Short tap on message remains no-op (does not steal normal scroll behavior).
+
+## Behavior Rules (Must Stay True)
+- Deleted messages show no action entry points.
+- Permissions stay unchanged:
+- React: authenticated user on active (non-deleted) message.
+- Edit: message owner only.
+- Delete: message owner or room creator.
+- Reaction API behavior remains server-authoritative and unchanged.
+- Existing delete confirmation modal stays in place for destructive confirmation.
+
+## Accessibility + Input Requirements
+- Desktop `...` trigger and shelf actions must have explicit `aria-label`s.
+- Desktop trigger/shelf must be keyboard reachable (`focus-within` visibility).
+- Mobile action menu supports close by outside tap and `Escape`.
+- Minimum action target size: 32px desktop, 40px mobile.
+- Long-press should not trigger while user is selecting text inside editable controls.
+
+## UI Structure Sketch (Frontend Only)
+- Keep message content in full-width flow.
+- Move row action controls out of flex width reservation into absolute overlay.
+- Introduce one reusable action surface component used by both:
+- Desktop `...` trigger -> anchored shelf.
+- Mobile long-press menu presentation.
+
+## Planned File Touches (Implementation Phase)
+- `frontend/src/components/message-list/MessageRow.tsx`
+- `frontend/src/components/message-list/MessageFeedContent.tsx` (if prop plumbing changes)
+- `frontend/src/components/message-list/` (new action menu/sheet component)
+- `frontend/src/components/__tests__/MessageList.test.tsx`
+- Optional: `frontend/src/hooks/` (small long-press helper if inline logic becomes noisy)
+
+## Implementation Slices
+1. Convert action rail to absolute overlay so hidden state does not consume width.
+2. Replace text action buttons with icon-only buttons + tooltips/aria labels.
+3. Add mobile long-press state + menu surface.
+4. Wire existing edit/delete/reaction handlers into new UI controls.
+5. Update tests for desktop visibility semantics and mobile long-press flow.
+
+## Verification
+```bash
+cd frontend && npx tsc --noEmit
+cd frontend && npx eslint src/
+cd frontend && npm run build
+cd frontend && npm test -- MessageList.test.tsx
+```
+
+## Decision Locks (Updated)
+- Locked: long-press threshold is `350ms`.
+- Locked: mobile menu surface is `bottom sheet`.
+- Locked: desktop shows a single hover/focus `...` trigger that opens the action shelf.
+- Locked: remove mobile fallback `...` trigger (long-press only on coarse pointer).
+
+## Bottom Sheet vs Anchored Popover
+- Bottom sheet: a panel that slides up from the bottom of the screen and spans most of the viewport width. Better thumb reach, larger targets, and more reliable on small screens.
+- Anchored popover: a small menu visually attached to the pressed message bubble. More contextual, but easier to clip/overflow on narrow screens and harder for one-handed use.
+- Recommendation for this task: `bottom sheet` first for mobile reliability and touch ergonomics.
+
+## Decision Brief (Whiteboard)
+- Chosen approach: input-modality split (desktop hover `...` + anchored shelf, mobile long-press bottom sheet) with no backend changes.
+- Alternative considered: single always-visible overflow button for both desktop and mobile.
+- Tradeoff: modality split adds small UI-state complexity but gives cleaner rows and less mobile visual noise.
+- Revisit trigger: if long-press discoverability tests fail, reintroduce a mobile fallback trigger.

--- a/plans/task-message-row-action-ux-sweep-01.md
+++ b/plans/task-message-row-action-ux-sweep-01.md
@@ -1,0 +1,53 @@
+## Goal
+Ship a frontend-only UI/UX sweep for message row actions so `react/edit/delete` are usable on mobile and denser on desktop.
+
+Suggested labels: `type:task`, `area:frontend`, `area:tests`, `area:docs`, `phase:3`, `status:ready`
+
+## Scope
+**In:**
+- Replace desktop text actions (`REACT/EDIT/DELETE`) with a single hover/focus `...` trigger + action shelf.
+- Keep desktop reveal behavior on hover/focus (`group-hover` + `focus-within`).
+- Remove fixed action-width reservation from message row layout.
+- Add mobile long-press (`350ms`) to open message action bottom sheet.
+- Remove persistent mobile fallback trigger so coarse-pointer mode uses long-press only.
+- Keep existing reaction/edit/delete handler contracts and permissions.
+- Update frontend tests for new affordances and interaction paths.
+
+**Out:**
+- Backend/API/WS schema or payload changes.
+- New dependencies.
+- Changes to edit/delete/reaction business rules.
+
+## Decision Locks
+- [x] Locked: execution mode is `single` (one Task -> one PR).
+- [x] Locked: mobile action surface is a **bottom sheet**.
+- [x] Locked: long-press threshold is **350ms**.
+- [x] Locked: desktop action affordance remains hover/focus reveal.
+- [x] Locked: desktop uses one hover/focus `...` trigger that opens an anchored action shelf.
+- [x] Locked: mobile has no persistent fallback `...` trigger (long-press only).
+- [x] Locked: deleted messages remain non-reactable/non-editable and show no action affordances.
+
+## Acceptance Criteria
+- [ ] Desktop message rows no longer reserve fixed horizontal space for hidden actions.
+- [ ] Desktop shows one hover/focus `...` trigger that opens anchored shelf actions.
+- [ ] Desktop buttons remain keyboard reachable and screen-reader labeled.
+- [ ] Mobile long-press on eligible message opens bottom sheet actions.
+- [ ] Mobile coarse-pointer mode relies on long-press only (no visible `...` fallback).
+- [ ] Bottom sheet presents quick reactions + allowed message actions + cancel.
+- [ ] Existing delete confirmation modal still gates destructive delete action.
+- [ ] Deleted messages do not expose action entry points.
+- [ ] Frontend tests are updated for desktop and mobile interaction paths.
+- [ ] Required frontend verification commands pass.
+
+## Verification
+```bash
+cd frontend && npx tsc --noEmit
+cd frontend && npx eslint src/
+cd frontend && npm run build
+cd frontend && npm test -- MessageList.test.tsx
+```
+
+## PR Checklist
+- [ ] PR references this issue (`Closes #...`).
+- [ ] Frontend tests added/updated for new interaction model.
+- [ ] Docs updated if reusable UI pattern guidance changed (`docs/PATTERNS.md`, `docs/REVIEW_CHECKLIST.md`).


### PR DESCRIPTION
## Summary
- replace desktop message action UI with a single hover/focus `...` trigger that opens an anchored action shelf
- keep mobile actions long-press driven with bottom-sheet presentation and remove persistent fallback trigger
- improve action menu readability and tighten quick-reaction sizing/row layout
- prevent desktop shelf clipping near viewport bottom by flipping placement above the trigger when needed
- update frontend tests and docs/whiteboard/task artifacts for the final interaction model

## Verification
- cd frontend && npx tsc --noEmit
- cd frontend && npx eslint src/
- cd frontend && npm run build
- cd frontend && npm test -- MessageList.test.tsx --reporter=verbose

Closes #34
